### PR TITLE
feat(sync): implement three-way merge for concurrent .md and .json edits

### DIFF
--- a/src-go/go.mod
+++ b/src-go/go.mod
@@ -16,13 +16,13 @@ require (
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
-	modernc.org/sqlite v1.49.1
+	modernc.org/sqlite v1.50.0
 )
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.4-0.20250417152128-c154b387248b // indirect
 	github.com/1password/onepassword-sdk-go v0.4.1-beta.1 // indirect
-	github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/byteness/go-keychain v0.0.0-20260108220220-c96c38f7f906 // indirect
 	github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 // indirect
 	github.com/byteness/percent v0.2.2 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
@@ -47,6 +47,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -55,7 +56,7 @@ require (
 	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
-	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/src-go/go.mod
+++ b/src-go/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jedisct1/go-aes-siv v1.0.0
 	github.com/rs/zerolog v1.35.1
+	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -47,7 +48,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/src-go/go.sum
+++ b/src-go/go.sum
@@ -6,8 +6,6 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK19hYuXB8OQ0rTO9WOCgZY9JUy964zaYawY=
-github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
 github.com/byteness/go-keychain v0.0.0-20260108220220-c96c38f7f906 h1:6I69EsMJulw9bfwwsOIoOVzN27/UJgHKHPRqsACeloQ=
 github.com/byteness/go-keychain v0.0.0-20260108220220-c96c38f7f906/go.mod h1:jgADfGMmAo24Ct+IHSywQ1qOpeXZtjk8WY6LZQftZ5w=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 h1:j59wGsxaBk6aFBuuYofk2oznMGZYyzFovjDqavlJHM8=
@@ -120,8 +118,6 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
-go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
@@ -174,8 +170,6 @@ modernc.org/opt v0.2.0 h1:tGyef5ApycA7FSEOMraay9SaTk5zmbx7Tu+cJs4QKZg=
 modernc.org/opt v0.2.0/go.mod h1:03fq9lsNfvkYSfxrfUhZCWPk1lm4cq4N+Bh//bEtgns=
 modernc.org/sortutil v1.2.1 h1:+xyoGf15mM3NMlPDnFqrteY07klSFxLElE2PVuWIJ7w=
 modernc.org/sortutil v1.2.1/go.mod h1:7ZI3a3REbai7gzCLcotuw9AC4VZVpYMjDzETGsSMqJE=
-modernc.org/sqlite v1.49.1 h1:dYGHTKcX1sJ+EQDnUzvz4TJ5GbuvhNJa8Fg6ElGx73U=
-modernc.org/sqlite v1.49.1/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 modernc.org/sqlite v1.50.0 h1:eMowQSWLK0MeiQTdmz3lqoF5dqclujdlIKeJA11+7oM=
 modernc.org/sqlite v1.50.0/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=

--- a/src-go/go.sum
+++ b/src-go/go.sum
@@ -8,6 +8,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK19hYuXB8OQ0rTO9WOCgZY9JUy964zaYawY=
 github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
+github.com/byteness/go-keychain v0.0.0-20260108220220-c96c38f7f906 h1:6I69EsMJulw9bfwwsOIoOVzN27/UJgHKHPRqsACeloQ=
+github.com/byteness/go-keychain v0.0.0-20260108220220-c96c38f7f906/go.mod h1:jgADfGMmAo24Ct+IHSywQ1qOpeXZtjk8WY6LZQftZ5w=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 h1:j59wGsxaBk6aFBuuYofk2oznMGZYyzFovjDqavlJHM8=
 github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0/go.mod h1:3FrDGTXj08zj6qtqlIvt0vS8eWNrrYpnXOEbcQgFmvM=
 github.com/byteness/keyring v1.9.1 h1:aWKEPoATzyZvVa641HhVhjUjHf35dl7DmCmr65+p+pE=
@@ -54,6 +56,7 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jedisct1/go-aes-siv v1.0.0 h1:1LUqYiKEvQhv1Pmwgi5DQMPPFxqT0cWmMPnzCNVYCO8=
 github.com/jedisct1/go-aes-siv v1.0.0/go.mod h1:Vugw21e5SVYJkUjKdP+Qqeqv3Dw6+0cBe8wPvVUSBIE=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -87,6 +90,8 @@ github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
+github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
+github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
@@ -102,6 +107,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -116,6 +122,8 @@ github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVK
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
@@ -137,8 +145,11 @@ golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.28.1 h1:XpLbkYVQ24E8tX5u8+yWGvaxerxkR/S4zqxI8ZoSBuc=
@@ -165,6 +176,8 @@ modernc.org/sortutil v1.2.1 h1:+xyoGf15mM3NMlPDnFqrteY07klSFxLElE2PVuWIJ7w=
 modernc.org/sortutil v1.2.1/go.mod h1:7ZI3a3REbai7gzCLcotuw9AC4VZVpYMjDzETGsSMqJE=
 modernc.org/sqlite v1.49.1 h1:dYGHTKcX1sJ+EQDnUzvz4TJ5GbuvhNJa8Fg6ElGx73U=
 modernc.org/sqlite v1.49.1/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
+modernc.org/sqlite v1.50.0 h1:eMowQSWLK0MeiQTdmz3lqoF5dqclujdlIKeJA11+7oM=
+modernc.org/sqlite v1.50.0/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=

--- a/src-go/internal/sync/continuous.go
+++ b/src-go/internal/sync/continuous.go
@@ -294,7 +294,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		version := cs.version
 		cs.mu.Unlock()
 
-		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote)
+		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 		e.Logger.Info().Int("planned_actions", len(plan)).Msg("continuous: sync plan created")
 
 		if len(plan) == 0 {

--- a/src-go/internal/sync/continuous.go
+++ b/src-go/internal/sync/continuous.go
@@ -16,20 +16,20 @@ import (
 )
 
 const (
-	continuousDebounce      = 500 * time.Millisecond
-	reconnectBackoff        = 5 * time.Second
-	heartbeatInterval       = 20 * time.Second
-	heartbeatSendThreshold  = 10 * time.Second
-	heartbeatTimeout        = 120 * time.Second
+	continuousDebounce     = 500 * time.Millisecond
+	reconnectBackoff       = 5 * time.Second
+	heartbeatInterval      = 20 * time.Second
+	heartbeatSendThreshold = 10 * time.Second
+	heartbeatTimeout       = 120 * time.Second
 )
 
 type continuousState struct {
-	mu             sync.Mutex
-	conn           *websocket.Conn
-	remote         map[string]model.FileRecord
-	version        int64
-	stopClose      func() bool
-	lastMessageTs  time.Time
+	mu            sync.Mutex
+	conn          *websocket.Conn
+	remote        map[string]model.FileRecord
+	version       int64
+	stopClose     func() bool
+	lastMessageTs time.Time
 }
 
 func (e *Engine) RunContinuous(ctx context.Context) error {
@@ -318,7 +318,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		session := newRemoteSession(connB, currentRemote, execVersion, ctx, e.enc, e.Logger, e.rawKey)
-		if err := e.executePlan(plan, currentLocal, session); err != nil {
+		if err := e.executePlan(plan, currentLocal, previousRemote, session); err != nil {
 			e.Logger.Error().Err(err).Msg("continuous: failed to execute plan")
 			return
 		}

--- a/src-go/internal/sync/engine.go
+++ b/src-go/internal/sync/engine.go
@@ -142,7 +142,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	}
 
 	session := newRemoteSession(e.conn, currentRemote, version, ctx, e.enc, e.Logger, e.rawKey)
-	if err := e.executePlan(plan, currentLocal, session); err != nil {
+	if err := e.executePlan(plan, currentLocal, previousRemote, session); err != nil {
 		return err
 	}
 
@@ -199,7 +199,7 @@ func (e *Engine) scanLocal() (map[string]model.FileRecord, error) {
 }
 
 // executePlan executes a list of sync actions.
-func (e *Engine) executePlan(plan []syncAction, currentLocal map[string]model.FileRecord, session *remoteSession) error {
+func (e *Engine) executePlan(plan []syncAction, currentLocal map[string]model.FileRecord, previousRemote map[string]model.FileRecord, session *remoteSession) error {
 	for _, action := range plan {
 		e.Logger.Debug().Str("kind", action.Kind.String()).Str("path", action.Path).Msg("action")
 		if action.Path == "" {
@@ -270,8 +270,125 @@ func (e *Engine) executePlan(plan []syncAction, currentLocal map[string]model.Fi
 			delete(session.remote, action.Path)
 			delete(currentLocal, action.Path)
 			e.Logger.Info().Str("path", action.Path).Msg("deleted local file")
+		case syncActionMergeText:
+			if err := e.mergeTextFile(action.Path, currentLocal, previousRemote, session); err != nil {
+				e.Logger.Warn().Err(err).Str("path", action.Path).Msg("merge failed, falling back to download")
+				record := session.remote[action.Path]
+				record.Path = action.Path
+				content, pullErr := session.pull(record.UID)
+				if pullErr != nil {
+					return pullErr
+				}
+				if writeErr := util.WriteFileWithTimes(e.Config.VaultPath, record, content); writeErr != nil {
+					return writeErr
+				}
+				e.Logger.Info().Str("path", action.Path).Msg("downloaded remote file (merge fallback)")
+			}
+		case syncActionMergeJSON:
+			if err := e.mergeJSONFile(action.Path, currentLocal, previousRemote, session); err != nil {
+				e.Logger.Warn().Err(err).Str("path", action.Path).Msg("JSON merge failed, falling back to download")
+				record := session.remote[action.Path]
+				record.Path = action.Path
+				content, pullErr := session.pull(record.UID)
+				if pullErr != nil {
+					return pullErr
+				}
+				if writeErr := util.WriteFileWithTimes(e.Config.VaultPath, record, content); writeErr != nil {
+					return writeErr
+				}
+				e.Logger.Info().Str("path", action.Path).Msg("downloaded remote file (JSON merge fallback)")
+			}
 		}
 	}
+	return nil
+}
+
+// mergeTextFile performs a three-way merge for a Markdown file.
+func (e *Engine) mergeTextFile(path string, currentLocal, previousRemote map[string]model.FileRecord, session *remoteSession) error {
+	localPath, err := util.SafeJoin(e.Config.VaultPath, path)
+	if err != nil {
+		return err
+	}
+	localContent, err := os.ReadFile(localPath)
+	if err != nil {
+		return fmt.Errorf("read local: %w", err)
+	}
+
+	baseRecord, hasBase := previousRemote[path]
+	var baseContent []byte
+	if hasBase && baseRecord.UID > 0 {
+		baseContent, err = session.pull(baseRecord.UID)
+		if err != nil {
+			e.Logger.Warn().Err(err).Str("path", path).Msg("failed to pull base version for merge")
+			baseContent = localContent
+		}
+	} else {
+		baseContent = localContent
+	}
+
+	remoteRecord := session.remote[path]
+	remoteContent, err := session.pull(remoteRecord.UID)
+	if err != nil {
+		return fmt.Errorf("pull remote: %w", err)
+	}
+
+	merged := threeWayMerge(string(baseContent), string(localContent), string(remoteContent))
+	mergedBytes := []byte(merged)
+
+	record := model.FileRecord{
+		Path:   path,
+		Size:   int64(len(mergedBytes)),
+		Hash:   util.HashBytes(mergedBytes),
+		CTime:  remoteRecord.CTime,
+		MTime:  max(remoteRecord.MTime, currentLocal[path].MTime),
+		Folder: false,
+	}
+	if err := util.WriteFileWithTimes(e.Config.VaultPath, record, mergedBytes); err != nil {
+		return err
+	}
+
+	currentLocal[path] = record
+	e.Logger.Info().Str("path", path).Msg("merged text file")
+	return nil
+}
+
+// mergeJSONFile performs a JSON object-key merge for a config file.
+func (e *Engine) mergeJSONFile(path string, currentLocal, previousRemote map[string]model.FileRecord, session *remoteSession) error {
+	localPath, err := util.SafeJoin(e.Config.VaultPath, path)
+	if err != nil {
+		return err
+	}
+	localContent, err := os.ReadFile(localPath)
+	if err != nil {
+		return fmt.Errorf("read local: %w", err)
+	}
+
+	remoteRecord := session.remote[path]
+	remoteContent, err := session.pull(remoteRecord.UID)
+	if err != nil {
+		return fmt.Errorf("pull remote: %w", err)
+	}
+
+	merged, err := jsonMerge(string(localContent), string(remoteContent))
+	if err != nil {
+		return err
+	}
+	mergedBytes := []byte(merged)
+
+	record := model.FileRecord{
+		Path:   path,
+		Size:   int64(len(mergedBytes)),
+		Hash:   util.HashBytes(mergedBytes),
+		CTime:  remoteRecord.CTime,
+		MTime:  max(remoteRecord.MTime, currentLocal[path].MTime),
+		Folder: false,
+	}
+	if err := util.WriteFileWithTimes(e.Config.VaultPath, record, mergedBytes); err != nil {
+		return err
+	}
+
+	currentLocal[path] = record
+	e.Logger.Info().Str("path", path).Msg("merged JSON config file")
 	return nil
 }
 

--- a/src-go/internal/sync/engine.go
+++ b/src-go/internal/sync/engine.go
@@ -125,7 +125,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	version := e.version
 	e.mu.Unlock()
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote)
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 	e.Logger.Info().
 		Int("planned_actions", len(plan)).
 		Int("local_files", len(currentLocal)).
@@ -148,7 +148,12 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 
 	e.mu.Lock()
 	e.version = session.version
-	maps.Copy(e.remote, currentRemote)
+	for path := range e.remote {
+		if _, ok := session.remote[path]; !ok {
+			delete(e.remote, path)
+		}
+	}
+	maps.Copy(e.remote, session.remote)
 	e.mu.Unlock()
 
 	// Rescan local after executing the plan so state reflects downloaded files
@@ -157,7 +162,14 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 		return err
 	}
 
-	if err := e.saveState(store, currentLocal, currentRemote, session.version); err != nil {
+	updatedRemote := make(map[string]model.FileRecord)
+	for path, record := range session.remote {
+		if isValidPath(path) {
+			updatedRemote[path] = record
+		}
+	}
+
+	if err := e.saveState(store, currentLocal, updatedRemote, session.version); err != nil {
 		return err
 	}
 
@@ -314,16 +326,20 @@ func (e *Engine) mergeTextFile(path string, currentLocal, previousRemote map[str
 		return fmt.Errorf("read local: %w", err)
 	}
 
+	localRecord, hasLocal := currentLocal[path]
+	if !hasLocal {
+		return fmt.Errorf("local record missing for merge of %q", path)
+	}
+
 	baseRecord, hasBase := previousRemote[path]
 	var baseContent []byte
 	if hasBase && baseRecord.UID > 0 {
 		baseContent, err = session.pull(baseRecord.UID)
 		if err != nil {
-			e.Logger.Warn().Err(err).Str("path", path).Msg("failed to pull base version for merge")
-			baseContent = localContent
+			return fmt.Errorf("pull base for three-way merge: %w", err)
 		}
 	} else {
-		baseContent = localContent
+		return fmt.Errorf("no base version available for three-way merge of %q", path)
 	}
 
 	remoteRecord := session.remote[path]
@@ -332,7 +348,10 @@ func (e *Engine) mergeTextFile(path string, currentLocal, previousRemote map[str
 		return fmt.Errorf("pull remote: %w", err)
 	}
 
-	merged := threeWayMerge(string(baseContent), string(localContent), string(remoteContent))
+	merged, err := threeWayMerge(string(baseContent), string(localContent), string(remoteContent))
+	if err != nil {
+		return fmt.Errorf("three-way merge failed: %w", err)
+	}
 	mergedBytes := []byte(merged)
 
 	record := model.FileRecord{
@@ -340,11 +359,15 @@ func (e *Engine) mergeTextFile(path string, currentLocal, previousRemote map[str
 		Size:   int64(len(mergedBytes)),
 		Hash:   util.HashBytes(mergedBytes),
 		CTime:  remoteRecord.CTime,
-		MTime:  max(remoteRecord.MTime, currentLocal[path].MTime),
+		MTime:  max(remoteRecord.MTime, localRecord.MTime),
 		Folder: false,
 	}
 	if err := util.WriteFileWithTimes(e.Config.VaultPath, record, mergedBytes); err != nil {
 		return err
+	}
+
+	if err := session.push(record, mergedBytes); err != nil {
+		return fmt.Errorf("push merged text file: %w", err)
 	}
 
 	currentLocal[path] = record
@@ -361,6 +384,11 @@ func (e *Engine) mergeJSONFile(path string, currentLocal, previousRemote map[str
 	localContent, err := os.ReadFile(localPath)
 	if err != nil {
 		return fmt.Errorf("read local: %w", err)
+	}
+
+	localRecord, hasLocal := currentLocal[path]
+	if !hasLocal {
+		return fmt.Errorf("local record missing for merge of %q", path)
 	}
 
 	remoteRecord := session.remote[path]
@@ -380,11 +408,15 @@ func (e *Engine) mergeJSONFile(path string, currentLocal, previousRemote map[str
 		Size:   int64(len(mergedBytes)),
 		Hash:   util.HashBytes(mergedBytes),
 		CTime:  remoteRecord.CTime,
-		MTime:  max(remoteRecord.MTime, currentLocal[path].MTime),
+		MTime:  max(remoteRecord.MTime, localRecord.MTime),
 		Folder: false,
 	}
 	if err := util.WriteFileWithTimes(e.Config.VaultPath, record, mergedBytes); err != nil {
 		return err
+	}
+
+	if err := session.push(record, mergedBytes); err != nil {
+		return fmt.Errorf("push merged JSON config file: %w", err)
 	}
 
 	currentLocal[path] = record

--- a/src-go/internal/sync/engine_test.go
+++ b/src-go/internal/sync/engine_test.go
@@ -363,7 +363,7 @@ func TestExecutePlan(t *testing.T) {
 	currentRemote := remote
 	previousRemote := map[string]model.FileRecord{}
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote)
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
 	if len(plan) != 2 {
 		t.Fatalf("expected 2 actions, got %d: %+v", len(plan), plan)
 	}

--- a/src-go/internal/sync/engine_test.go
+++ b/src-go/internal/sync/engine_test.go
@@ -370,7 +370,7 @@ func TestExecutePlan(t *testing.T) {
 
 	ctx := context.Background()
 	session := newRemoteSession(conn, remote, 1, ctx, nil, testLogger(), nil)
-	if err := e.executePlan(plan, currentLocal, session); err != nil {
+	if err := e.executePlan(plan, currentLocal, previousRemote, session); err != nil {
 		t.Fatal(err)
 	}
 

--- a/src-go/internal/sync/merge.go
+++ b/src-go/internal/sync/merge.go
@@ -1,0 +1,61 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"path/filepath"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// threeWayMerge performs a diff-match-patch based three-way text merge.
+// It computes the difference between base and local, turns those diffs
+// into patches, and applies them to remote.
+func threeWayMerge(base, local, remote string) string {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(base, local, true)
+	diffs = dmp.DiffCleanupSemantic(diffs)
+	diffs = dmp.DiffCleanupEfficiency(diffs)
+	patches := dmp.PatchMake(base, diffs)
+	merged, _ := dmp.PatchApply(patches, remote)
+	return merged
+}
+
+// jsonMerge merges two JSON objects. Server keys win on conflict.
+func jsonMerge(localJSON, remoteJSON string) (string, error) {
+	var localObj, remoteObj map[string]any
+	if err := json.Unmarshal([]byte(localJSON), &localObj); err != nil {
+		return "", fmt.Errorf("invalid local JSON: %w", err)
+	}
+	if err := json.Unmarshal([]byte(remoteJSON), &remoteObj); err != nil {
+		return "", fmt.Errorf("invalid remote JSON: %w", err)
+	}
+	merged := make(map[string]any, len(localObj)+len(remoteObj))
+	maps.Copy(merged, localObj)
+	maps.Copy(merged, remoteObj)
+	out, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal merged JSON: %w", err)
+	}
+	return string(out), nil
+}
+
+// isMergeablePath returns true if the file should use merge conflict
+// resolution instead of last-write-wins when both sides changed.
+func isMergeablePath(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == ".md"
+}
+
+// isJSONConfigPath returns true if the file is a JSON file inside the
+// config directory and should use JSON object-key merging.
+func isJSONConfigPath(path, configDir string) bool {
+	if filepath.Ext(path) != ".json" {
+		return false
+	}
+	if configDir == "" {
+		configDir = ".obsidian"
+	}
+	return filepath.Dir(path) == configDir
+}

--- a/src-go/internal/sync/merge.go
+++ b/src-go/internal/sync/merge.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
@@ -12,17 +14,23 @@ import (
 // threeWayMerge performs a diff-match-patch based three-way text merge.
 // It computes the difference between base and local, turns those diffs
 // into patches, and applies them to remote.
-func threeWayMerge(base, local, remote string) string {
+func threeWayMerge(base, local, remote string) (string, error) {
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(base, local, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)
 	diffs = dmp.DiffCleanupEfficiency(diffs)
 	patches := dmp.PatchMake(base, diffs)
-	merged, _ := dmp.PatchApply(patches, remote)
-	return merged
+	merged, results := dmp.PatchApply(patches, remote)
+	for _, ok := range results {
+		if !ok {
+			return merged, fmt.Errorf("patch failed to apply")
+		}
+	}
+	return merged, nil
 }
 
 // jsonMerge merges two JSON objects. Server keys win on conflict.
+// For overlapping map values, it recurses; for scalar/array conflicts, remote wins.
 func jsonMerge(localJSON, remoteJSON string) (string, error) {
 	var localObj, remoteObj map[string]any
 	if err := json.Unmarshal([]byte(localJSON), &localObj); err != nil {
@@ -31,14 +39,31 @@ func jsonMerge(localJSON, remoteJSON string) (string, error) {
 	if err := json.Unmarshal([]byte(remoteJSON), &remoteObj); err != nil {
 		return "", fmt.Errorf("invalid remote JSON: %w", err)
 	}
-	merged := make(map[string]any, len(localObj)+len(remoteObj))
-	maps.Copy(merged, localObj)
-	maps.Copy(merged, remoteObj)
+	merged := deepMergeJSON(localObj, remoteObj)
 	out, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal merged JSON: %w", err)
 	}
 	return string(out), nil
+}
+
+// deepMergeJSON merges remote into local. For overlapping map values,
+// it recurses; for scalar/array conflicts, remote wins.
+func deepMergeJSON(local, remote map[string]any) map[string]any {
+	out := make(map[string]any, len(local)+len(remote))
+	maps.Copy(out, local)
+	for k, rv := range remote {
+		if lv, ok := out[k]; ok {
+			if lm, lok := lv.(map[string]any); lok {
+				if rm, rok := rv.(map[string]any); rok {
+					out[k] = deepMergeJSON(lm, rm)
+					continue
+				}
+			}
+		}
+		out[k] = rv
+	}
+	return out
 }
 
 // isMergeablePath returns true if the file should use merge conflict
@@ -49,13 +74,17 @@ func isMergeablePath(path string) bool {
 }
 
 // isJSONConfigPath returns true if the file is a JSON file inside the
-// config directory and should use JSON object-key merging.
-func isJSONConfigPath(path, configDir string) bool {
-	if filepath.Ext(path) != ".json" {
+// config directory (or any subdirectory) and should use JSON object-key merging.
+func isJSONConfigPath(pathStr, configDir string) bool {
+	// Normalize to forward slashes for consistent prefix matching
+	normPath := strings.ReplaceAll(pathStr, "\\", "/")
+	if path.Ext(normPath) != ".json" {
 		return false
 	}
 	if configDir == "" {
 		configDir = ".obsidian"
 	}
-	return filepath.Dir(path) == configDir
+	normDir := strings.ReplaceAll(configDir, "\\", "/")
+	dir := path.Dir(normPath)
+	return dir == normDir || strings.HasPrefix(dir, normDir+"/")
 }

--- a/src-go/internal/sync/merge_test.go
+++ b/src-go/internal/sync/merge_test.go
@@ -51,7 +51,11 @@ func TestThreeWayMerge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := threeWayMerge(tt.base, tt.local, tt.remote)
+			got, err := threeWayMerge(tt.base, tt.local, tt.remote)
+			if err != nil {
+				t.Errorf("threeWayMerge() unexpected error = %v", err)
+				return
+			}
 			if got != tt.want {
 				t.Errorf("threeWayMerge() = %q, want %q", got, tt.want)
 			}
@@ -83,7 +87,7 @@ func TestJSONMerge(t *testing.T) {
 			name:       "nested objects",
 			localJSON:  `{"x": {"a": 1}}`,
 			remoteJSON: `{"x": {"b": 2}}`,
-			want:       "{\n  \"x\": {\n    \"b\": 2\n  }\n}",
+			want:       "{\n  \"x\": {\n    \"a\": 1,\n    \"b\": 2\n  }\n}",
 		},
 		{
 			name:       "invalid local JSON",
@@ -144,6 +148,11 @@ func TestIsJSONConfigPath(t *testing.T) {
 		{"notes/config.json", ".obsidian", false},
 		{".obsidian/theme.css", ".obsidian", false},
 		{".obsidian/config.json", "", true},
+		{".obsidian/plugins/dataview/data.json", ".obsidian", true},
+		{".obsidian/themes/Things/manifest.json", ".obsidian", true},
+		{".obsidian\\plugins\\dataview\\data.json", ".obsidian", true},
+		{"custom-dir/app.json", "custom-dir", true},
+		{"custom-dir/plugins/x/data.json", "custom-dir", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/src-go/internal/sync/merge_test.go
+++ b/src-go/internal/sync/merge_test.go
@@ -1,0 +1,155 @@
+package sync
+
+import (
+	"testing"
+)
+
+func TestThreeWayMerge(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		local  string
+		remote string
+		want   string
+	}{
+		{
+			name:   "non-overlapping edits",
+			base:   "A\nB\nC\n",
+			local:  "A\nB\nC local\n",
+			remote: "A remote\nB\nC\n",
+			want:   "A remote\nB\nC local\n",
+		},
+		{
+			name:   "same edit both sides",
+			base:   "A\nB\nC\n",
+			local:  "A\nB\nD\n",
+			remote: "A\nB\nD\n",
+			want:   "A\nB\nD\n",
+		},
+		{
+			name:   "local only changed",
+			base:   "A\nB\nC\n",
+			local:  "A\nB\nD\n",
+			remote: "A\nB\nC\n",
+			want:   "A\nB\nD\n",
+		},
+		{
+			name:   "remote only changed",
+			base:   "A\nB\nC\n",
+			local:  "A\nB\nC\n",
+			remote: "A\nB\nD\n",
+			want:   "A\nB\nD\n",
+		},
+		{
+			name:   "conflicting edits",
+			base:   "A\nB\nC\n",
+			local:  "A\nX\nC\n",
+			remote: "A\nY\nC\n",
+			want:   "A\nX\nC\n", // patch falls back to replacing near original position
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := threeWayMerge(tt.base, tt.local, tt.remote)
+			if got != tt.want {
+				t.Errorf("threeWayMerge() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONMerge(t *testing.T) {
+	tests := []struct {
+		name       string
+		localJSON  string
+		remoteJSON string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "disjoint keys",
+			localJSON:  `{"a": 1}`,
+			remoteJSON: `{"b": 2}`,
+			want:       "{\n  \"a\": 1,\n  \"b\": 2\n}",
+		},
+		{
+			name:       "server wins conflict",
+			localJSON:  `{"a": 1}`,
+			remoteJSON: `{"a": 2}`,
+			want:       "{\n  \"a\": 2\n}",
+		},
+		{
+			name:       "nested objects",
+			localJSON:  `{"x": {"a": 1}}`,
+			remoteJSON: `{"x": {"b": 2}}`,
+			want:       "{\n  \"x\": {\n    \"b\": 2\n  }\n}",
+		},
+		{
+			name:       "invalid local JSON",
+			localJSON:  `not json`,
+			remoteJSON: `{"a": 1}`,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid remote JSON",
+			localJSON:  `{"a": 1}`,
+			remoteJSON: `not json`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jsonMerge(tt.localJSON, tt.remoteJSON)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jsonMerge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("jsonMerge() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMergeablePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"note.md", true},
+		{"dir/note.md", true},
+		{"config.json", false},
+		{"image.png", false},
+		{"noext", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isMergeablePath(tt.path); got != tt.want {
+				t.Errorf("isMergeablePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsJSONConfigPath(t *testing.T) {
+	tests := []struct {
+		path      string
+		configDir string
+		want      bool
+	}{
+		{".obsidian/app.json", ".obsidian", true},
+		{".obsidian/appearance.json", ".obsidian", true},
+		{"notes/config.json", ".obsidian", false},
+		{".obsidian/theme.css", ".obsidian", false},
+		{".obsidian/config.json", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isJSONConfigPath(tt.path, tt.configDir); got != tt.want {
+				t.Errorf("isJSONConfigPath(%q, %q) = %v, want %v", tt.path, tt.configDir, got, tt.want)
+			}
+		})
+	}
+}

--- a/src-go/internal/sync/plan.go
+++ b/src-go/internal/sync/plan.go
@@ -41,7 +41,7 @@ type syncAction struct {
 	Kind syncActionKind
 }
 
-func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[string]model.FileRecord) []syncAction {
+func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[string]model.FileRecord, configDir string) []syncAction {
 	pathsSet := map[string]struct{}{}
 	for _, collection := range []map[string]model.FileRecord{currentLocal, previousLocal, currentRemote, previousRemote} {
 		for path := range collection {
@@ -82,16 +82,25 @@ func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[st
 				// Neither side has an active file, nothing to do
 				break
 			}
-			// Both sides have active changes. Use merge for supported types,
-			// otherwise fall back to mtime-based winner.
-			if isMergeablePath(path) {
-				actions = append(actions, syncAction{Path: path, Kind: syncActionMergeText})
-			} else if isJSONConfigPath(path, ".obsidian") {
-				actions = append(actions, syncAction{Path: path, Kind: syncActionMergeJSON})
-			} else if chooseRemote(hasCurrentL, currentL, hasCurrentR, currentR, hasPreviousL, previousL, hasPreviousR, previousR) {
-				actions = append(actions, syncAction{Path: path, Kind: syncActionDownload})
+			if hasCurrentL {
+				// Both sides have active changes. Use merge for supported types,
+				// otherwise fall back to mtime-based winner.
+				if isMergeablePath(path) {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionMergeText})
+				} else if isJSONConfigPath(path, configDir) {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionMergeJSON})
+				} else if chooseRemote(hasCurrentL, currentL, hasCurrentR, currentR, hasPreviousL, previousL, hasPreviousR, previousR) {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionDownload})
+				} else {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionUpload})
+				}
 			} else {
-				actions = append(actions, syncAction{Path: path, Kind: syncActionUpload})
+				// Local deleted, remote changed - fall back to mtime-based winner.
+				if chooseRemote(hasCurrentL, currentL, hasCurrentR, currentR, hasPreviousL, previousL, hasPreviousR, previousR) {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionDownload})
+				} else if serverHasActiveFile {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionDeleteRemote})
+				}
 			}
 		case remoteChanged:
 			if serverHasActiveFile {

--- a/src-go/internal/sync/plan.go
+++ b/src-go/internal/sync/plan.go
@@ -13,6 +13,8 @@ const (
 	syncActionUpload
 	syncActionDeleteRemote
 	syncActionDeleteLocal
+	syncActionMergeText
+	syncActionMergeJSON
 )
 
 func (k syncActionKind) String() string {
@@ -25,6 +27,10 @@ func (k syncActionKind) String() string {
 		return "delete-remote"
 	case syncActionDeleteLocal:
 		return "delete-local"
+	case syncActionMergeText:
+		return "merge-text"
+	case syncActionMergeJSON:
+		return "merge-json"
 	default:
 		return "unknown"
 	}
@@ -65,19 +71,27 @@ func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[st
 
 		switch {
 		case remoteChanged && localChanged:
-			if chooseRemote(hasCurrentL, currentL, hasCurrentR, currentR, hasPreviousL, previousL, hasPreviousR, previousR) {
-				if serverHasActiveFile {
-					actions = append(actions, syncAction{Path: path, Kind: syncActionDownload})
-				} else if serverHasDeletedRecord {
-					// Server deleted, local changed - conflict. For now, let local win (upload)
-					// TODO: implement proper conflict resolution
-					_ = serverHasDeletedRecord
+			if serverHasDeletedRecord {
+				// Server deleted, local changed - let local win (upload)
+				if hasCurrentL {
+					actions = append(actions, syncAction{Path: path, Kind: syncActionUpload})
 				}
+				break
 			}
-			if hasCurrentL {
+			if !serverHasActiveFile {
+				// Neither side has an active file, nothing to do
+				break
+			}
+			// Both sides have active changes. Use merge for supported types,
+			// otherwise fall back to mtime-based winner.
+			if isMergeablePath(path) {
+				actions = append(actions, syncAction{Path: path, Kind: syncActionMergeText})
+			} else if isJSONConfigPath(path, ".obsidian") {
+				actions = append(actions, syncAction{Path: path, Kind: syncActionMergeJSON})
+			} else if chooseRemote(hasCurrentL, currentL, hasCurrentR, currentR, hasPreviousL, previousL, hasPreviousR, previousR) {
+				actions = append(actions, syncAction{Path: path, Kind: syncActionDownload})
+			} else {
 				actions = append(actions, syncAction{Path: path, Kind: syncActionUpload})
-			} else if serverHasActiveFile {
-				actions = append(actions, syncAction{Path: path, Kind: syncActionDeleteRemote})
 			}
 		case remoteChanged:
 			if serverHasActiveFile {


### PR DESCRIPTION
## Summary

When both local and remote changed the same file since the last sync, the previous Go code always uploaded the local version unconditionally, silently overwriting remote changes.

This PR ports the TypeScript client's merge logic for conflict resolution.

## Changes

### New merge engine (`merge.go`)

- **Markdown files (`.md`)**: uses diff-match-patch three-way merge. Computes base→local diffs, turns them into patches, and applies them to the remote text. This gracefully merges non-overlapping edits (e.g. you added a heading, they added a paragraph).
  
- **Config JSON files (`.obsidian/*.json`)**: uses object-key merge where server keys win on conflict. This preserves local keys while accepting remote overrides.

- **Other file types**: keep existing mtime-based winner logic.

### New action kinds (`plan.go`)

Added `syncActionMergeText` and `syncActionMergeJSON`. `buildPlan` now emits merge actions when both sides changed a supported file type.

### Updated execution flow

- `executePlan` signature extended to accept `previousRemote` (needed to pull the base version for three-way merge)
- `mergeTextFile` and `mergeJSONFile` handlers added with fallback to download on failure
- Both `RunOnce` and `RunContinuous` updated to pass `previousRemote`

### Tests

- `merge_test.go`: unit tests for `threeWayMerge`, `jsonMerge`, `isMergeablePath`, `isJSONConfigPath`

### Dependencies

- `github.com/sergi/go-diff v1.4.0` (Google diff-match-patch port)

## Quality checks

- `go fmt ./...` ✓
- `go vet ./...` ✓
- `staticcheck ./...` ✓
- `go test ./...` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent conflict resolution during synchronization that automatically merges compatible text and JSON files when both local and remote changes exist; incompatible files revert to standard resolution behavior.

* **Chores**
  * Updated Go module dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->