### PR TITLE
fix(build): add /command to PATH in get-token entrypoint

### DIFF
--- a/build/get-token.sh
+++ b/build/get-token.sh
@@ -12,12 +12,23 @@ set -e
 # when run outside the container (e.g. during development).
 export HOME="${HOME:-/home/obsidian}"
 
+# s6-overlay v3 installs binaries under /command. When this script is used as
+# an entrypoint override, /init (which normally adjusts PATH) is bypassed, so
+# we ensure /command is on PATH here.
+export PATH="/command:$PATH"
+
 echo ""
 echo "=== obsidian-headless: Login ==="
 echo ""
 echo "Log in to your Obsidian account."
 echo "You will be prompted for your email, password, and MFA code (if enabled)."
 echo ""
+
+# Ensure the config directory exists and is owned by the obsidian user.
+# When this script is used as an entrypoint override, s6-overlay init
+# (which normally fixes ownership) is bypassed, so we do it here.
+mkdir -p /home/obsidian/.config
+chown -R obsidian:obsidian /home/obsidian/.config
 
 # Run login as the obsidian user so the token is stored in the right place
 s6-setuidgid obsidian ob login

--- a/build/get-token.sh
+++ b/build/get-token.sh
@@ -15,7 +15,7 @@ export HOME="${HOME:-/home/obsidian}"
 # s6-overlay v3 installs binaries under /command. When this script is used as
 # an entrypoint override, /init (which normally adjusts PATH) is bypassed, so
 # we ensure /command is on PATH here.
-export PATH="/command:$PATH"
+export PATH="/command${PATH:+:$PATH}"
 
 echo ""
 echo "=== obsidian-headless: Login ==="


### PR DESCRIPTION
## Summary

Fixes `s6-setuidgid: not found` when running the `get-token` entrypoint override in Docker.

## Problem

`s6-overlay` v3 installs binaries under `/command`, which is normally added to `PATH` by `/init`. When users override the entrypoint with `--entrypoint get-token`, `/init` is bypassed and `s6-setuidgid` is not found.

## Fix

Explicitly prepend `/command` to `PATH` in `build/get-token.sh` so the script works both as an entrypoint override and under normal s6 supervision.

## Testing

```bash
docker run --rm -it \
  -v ./config:/home/obsidian/.config \
  --entrypoint get-token \
  ghcr.io/belphemur/obsidian-headless:latest
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build initialization process to ensure system utilities remain accessible during startup, while maintaining compatibility with existing authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->