### PR TITLE
feat(cli): add loading spinner to login flow

### DIFF
--- a/src/internal/cli/auth.go
+++ b/src/internal/cli/auth.go
@@ -63,7 +63,7 @@ func newLoginCommand(app *App) *cobra.Command {
 			}
 
 			// Attempt login
-			sp := newSpinner(app.stdout, "Logging in...")
+			sp := newSpinner(app.stderr, "Logging in...")
 			sp.Start()
 			response, err := app.client().SignIn(cmd.Context(), email, password, mfa)
 			sp.Stop()
@@ -75,7 +75,7 @@ func newLoginCommand(app *App) *cobra.Command {
 					_, _ = fmt.Fprint(app.stdout, "2FA code: ")
 					_, _ = fmt.Scanln(&mfa)
 					if mfa != "" {
-						sp := newSpinner(app.stdout, "Logging in...")
+						sp := newSpinner(app.stderr, "Logging in...")
 						sp.Start()
 						response, err = app.client().SignIn(cmd.Context(), email, password, mfa)
 						sp.Stop()

--- a/src/internal/cli/auth.go
+++ b/src/internal/cli/auth.go
@@ -56,21 +56,29 @@ func newLoginCommand(app *App) *cobra.Command {
 					return err
 				}
 				password = pass
+				_, _ = fmt.Fprintln(app.stdout)
 			}
 			if email == "" || password == "" {
 				return fmt.Errorf("both --email and --password are required")
 			}
 
 			// Attempt login
+			sp := newSpinner(app.stdout, "Logging in...")
+			sp.Start()
 			response, err := app.client().SignIn(cmd.Context(), email, password, mfa)
+			sp.Stop()
 			if err != nil {
 				// Check if 2FA is required using APIError type (server returns 200 with error in body)
 				var apiErr *apipkg.APIError
 				if errors.As(err, &apiErr) && strings.Contains(strings.ToLower(apiErr.Message), "2fa") && mfa == "" {
+					writeLines(app.stdout, "")
 					_, _ = fmt.Fprint(app.stdout, "2FA code: ")
 					_, _ = fmt.Scanln(&mfa)
 					if mfa != "" {
+						sp := newSpinner(app.stdout, "Logging in...")
+						sp.Start()
 						response, err = app.client().SignIn(cmd.Context(), email, password, mfa)
+						sp.Stop()
 						if err != nil {
 							return fmt.Errorf("login failed: %w", err)
 						}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -77,4 +79,40 @@ func readPassword(input io.Reader) (string, error) {
 		return "", err
 	}
 	return string(passwordBytes), nil
+}
+
+type cliSpinner struct {
+	w    io.Writer
+	msg  string
+	done chan struct{}
+	tick *time.Ticker
+}
+
+func newSpinner(w io.Writer, msg string) *cliSpinner {
+	return &cliSpinner{w: w, msg: msg}
+}
+
+func (s *cliSpinner) Start() {
+	s.done = make(chan struct{})
+	s.tick = time.NewTicker(100 * time.Millisecond)
+	go func() {
+		frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+		i := 0
+		for {
+			select {
+			case <-s.tick.C:
+				_, _ = fmt.Fprintf(s.w, "\r%s %s", frames[i%len(frames)], s.msg)
+				i++
+			case <-s.done:
+				s.tick.Stop()
+				clearLen := utf8.RuneCountInString(frames[0]) + 1 + utf8.RuneCountInString(s.msg)
+				_, _ = fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", clearLen))
+				return
+			}
+		}
+	}()
+}
+
+func (s *cliSpinner) Stop() {
+	close(s.done)
 }

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -82,10 +83,12 @@ func readPassword(input io.Reader) (string, error) {
 }
 
 type cliSpinner struct {
-	w    io.Writer
-	msg  string
-	done chan struct{}
-	tick *time.Ticker
+	w       io.Writer
+	msg     string
+	done    chan struct{}
+	stopped chan struct{}
+	tick    *time.Ticker
+	once    sync.Once
 }
 
 func newSpinner(w io.Writer, msg string) *cliSpinner {
@@ -93,9 +96,15 @@ func newSpinner(w io.Writer, msg string) *cliSpinner {
 }
 
 func (s *cliSpinner) Start() {
+	// Only animate if output is a terminal
+	if f, ok := s.w.(*os.File); !ok || !term.IsTerminal(int(f.Fd())) {
+		return
+	}
 	s.done = make(chan struct{})
+	s.stopped = make(chan struct{})
 	s.tick = time.NewTicker(100 * time.Millisecond)
 	go func() {
+		defer close(s.stopped)
 		frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 		i := 0
 		for {
@@ -114,5 +123,11 @@ func (s *cliSpinner) Start() {
 }
 
 func (s *cliSpinner) Stop() {
-	close(s.done)
+	s.once.Do(func() {
+		if s.done == nil {
+			return
+		}
+		close(s.done)
+		<-s.stopped
+	})
 }


### PR DESCRIPTION
## Summary

Improves the interactive login experience by adding a lightweight spinner and better visual separation.

### Changes

- **Loading indicator**: A modern Unicode spinner (Braille dots) is shown after entering the password while waiting for the server to respond.
- **MFA prompt spacing**: Added a blank line before the 2FA code prompt so it doesn't appear glued to the previous output.
- **Second loading indicator**: The spinner is shown again after the MFA code is submitted while the second sign-in request is in flight.
- **Newline after password**: Ensures the cursor moves to a new line after reading the password interactively, keeping the terminal output clean.

The spinner implementation is zero-dependency and lives entirely in the `cli` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Logging in..." progress indicator during authentication attempts.

* **Style**
  * Improved console spacing with newlines after password input and before two-factor authentication prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->