### PR TITLE
fix(sync): keep heartbeat alive across reconnects and add exponential backoff

### DIFF
--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -18,6 +18,7 @@ import (
 const (
 	continuousDebounce     = 500 * time.Millisecond
 	reconnectBackoff       = 5 * time.Second
+	maxReconnectBackoff    = 60 * time.Second
 	heartbeatInterval      = 20 * time.Second
 	heartbeatSendThreshold = 10 * time.Second
 	heartbeatTimeout       = 120 * time.Second
@@ -215,7 +216,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 					cs.mu.Unlock()
 
 					if conn == nil {
-						return
+						continue
 					}
 
 					elapsed := time.Since(lastMsg)
@@ -223,14 +224,25 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 					if elapsed >= heartbeatTimeout {
 						e.Logger.Warn().Dur("elapsed", elapsed).Msg("continuous: heartbeat timeout, closing connection")
 						_ = conn.Close()
-						return
+						cs.mu.Lock()
+						if cs.conn == conn {
+							cs.conn = nil
+						}
+						cs.mu.Unlock()
+						continue
 					}
 					if elapsed >= heartbeatSendThreshold {
 						if err := conn.WriteJSON(map[string]any{"op": "ping"}); err != nil {
-							e.Logger.Warn().Err(err).Msg("continuous: failed to send ping")
-						} else {
-							e.Logger.Debug().Dur("elapsed", elapsed).Msg("continuous: sent ping")
+							e.Logger.Warn().Err(err).Msg("continuous: failed to send ping, closing connection")
+							_ = conn.Close()
+							cs.mu.Lock()
+							if cs.conn == conn {
+								cs.conn = nil
+							}
+							cs.mu.Unlock()
+							continue
 						}
+						e.Logger.Debug().Dur("elapsed", elapsed).Msg("continuous: sent ping")
 					}
 				}
 			}
@@ -400,14 +412,20 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			clear(cs.remote)
 			cs.mu.Unlock()
 
+			backoff := reconnectBackoff
+
 		reconnectLoop:
 			for {
 				select {
 				case <-ctx.Done():
 					return nil
-				case <-time.After(reconnectBackoff):
+				case <-time.After(backoff):
 					if err := connect(); err != nil {
 						e.Logger.Error().Err(err).Msg("continuous: reconnection failed, retrying...")
+					backoff *= 2
+					if backoff > maxReconnectBackoff {
+						backoff = maxReconnectBackoff
+					}
 						continue reconnectLoop
 					}
 					startReadPump()

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -107,12 +107,14 @@ func TestContinuousWatcherSync(t *testing.T) {
 
 	// Verify file was uploaded to mock server
 	found := false
+	mock.mu.Lock()
 	for _, content := range mock.contentByUID {
 		if string(content) == "new content" {
 			found = true
 			break
 		}
 	}
+	mock.mu.Unlock()
 	if !found {
 		t.Fatal("file was not uploaded by continuous sync")
 	}
@@ -175,12 +177,14 @@ func TestContinuousPushSync(t *testing.T) {
 
 	// Verify local file was uploaded
 	found := false
+	mock.mu.Lock()
 	for _, content := range mock.contentByUID {
 		if string(content) == "local content" {
 			found = true
 			break
 		}
 	}
+	mock.mu.Unlock()
 	if !found {
 		t.Fatal("local file was not uploaded")
 	}
@@ -238,12 +242,14 @@ func TestContinuousReconnection(t *testing.T) {
 	time.Sleep(4 * time.Second)
 
 	found := false
+	mock.mu.Lock()
 	for _, content := range mock.contentByUID {
 		if string(content) == "after reconnect" {
 			found = true
 			break
 		}
 	}
+	mock.mu.Unlock()
 	if !found {
 		t.Fatal("file was not uploaded after reconnection")
 	}
@@ -421,8 +427,86 @@ func TestContinuousInitialSyncWithStaleState(t *testing.T) {
 	}
 
 	// Verify the mock server still has the remote file
-	if len(mock.recordsByPath) != 1 {
-		t.Fatalf("remote file was incorrectly deleted from server; expected 1 record, got %d", len(mock.recordsByPath))
+	mock.mu.Lock()
+	recordCount := len(mock.recordsByPath)
+	mock.mu.Unlock()
+	if recordCount != 1 {
+		t.Fatalf("remote file was incorrectly deleted from server; expected 1 record, got %d", recordCount)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil && err != context.Canceled {
+		t.Fatalf("RunContinuous error: %v", err)
+	}
+}
+
+func TestContinuousHeartbeatAfterReconnect(t *testing.T) {
+	mock := newMockSyncServer(t)
+
+	server := httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	wsURL := "ws://" + u.Host
+
+	vault := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "state.db")
+
+	e := &Engine{
+		Config: model.SyncConfig{
+			VaultID:   "test-heartbeat-reconnect-vault",
+			VaultPath: vault,
+			Host:      wsURL,
+			StatePath: statePath,
+			ConfigDir: ".obsidian",
+		},
+		Logger: testLogger(),
+	}
+
+	// The server will close the WebSocket after responding to the first ping.
+	// This forces a reconnect so we can verify the heartbeat restarts.
+	mock.closeAfterPing = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- e.RunContinuous(ctx)
+	}()
+
+	// Wait for the first ping (server will close connection after pong)
+	var initialPings int
+	foundInitial := false
+	for range 60 {
+		time.Sleep(500 * time.Millisecond)
+		mock.mu.Lock()
+		initialPings = mock.pingCount
+		mock.mu.Unlock()
+		if initialPings > 0 {
+			foundInitial = true
+			break
+		}
+	}
+	if !foundInitial {
+		t.Fatal("expected at least one ping on initial connection")
+	}
+
+	// After the server closed the connection, the client should reconnect
+	// and the heartbeat should resume, sending another ping.
+	foundAfterReconnect := false
+	for range 60 {
+		time.Sleep(500 * time.Millisecond)
+		mock.mu.Lock()
+		finalPings := mock.pingCount
+		mock.mu.Unlock()
+		if finalPings > initialPings {
+			foundAfterReconnect = true
+			break
+		}
+	}
+	if !foundAfterReconnect {
+		t.Fatalf("expected ping after reconnect")
 	}
 
 	cancel()

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -137,11 +138,14 @@ func TestSaveState(t *testing.T) {
 }
 
 type mockSyncServer struct {
-	t             *testing.T
-	recordsByUID  map[int64]model.FileRecord
-	recordsByPath map[string]model.FileRecord
-	contentByUID  map[int64][]byte
-	upgrader      websocket.Upgrader
+	t              *testing.T
+	mu             sync.Mutex
+	recordsByUID   map[int64]model.FileRecord
+	recordsByPath  map[string]model.FileRecord
+	contentByUID   map[int64][]byte
+	upgrader       websocket.Upgrader
+	pingCount      int
+	closeAfterPing bool
 }
 
 func newMockSyncServer(t *testing.T) *mockSyncServer {
@@ -164,6 +168,8 @@ func (s *mockSyncServer) addRecord(path string, uid int64, content []byte) {
 		UID:     uid,
 		Deleted: false,
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.recordsByUID[uid] = record
 	s.recordsByPath[path] = record
 	s.contentByUID[uid] = content
@@ -197,7 +203,13 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			// Send any existing records as pushes
+			s.mu.Lock()
+			records := make([]model.FileRecord, 0, len(s.recordsByUID))
 			for _, record := range s.recordsByUID {
+				records = append(records, record)
+			}
+			s.mu.Unlock()
+			for _, record := range records {
 				if err := conn.WriteJSON(map[string]any{
 					"op":      "push",
 					"path":    record.Path,
@@ -217,7 +229,10 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		case "pull":
 			uid := int64Value(msg["uid"])
+			s.mu.Lock()
 			record, ok := s.recordsByUID[uid]
+			content := s.contentByUID[uid]
+			s.mu.Unlock()
 			if !ok {
 				if err := conn.WriteJSON(map[string]any{"res": "err", "msg": "not found"}); err != nil {
 					return
@@ -230,7 +245,6 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				continue
 			}
-			content := s.contentByUID[uid]
 			pieces := 0
 			if len(content) > 0 {
 				pieces = (len(content) + chunkSize - 1) / chunkSize
@@ -299,14 +313,27 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 					} else {
 						record.Hash = fmt.Sprintf("%x", content)
+						s.mu.Lock()
 						s.recordsByUID[uid] = record
 						s.recordsByPath[path] = record
 						s.contentByUID[uid] = content
+						s.mu.Unlock()
 						if err := conn.WriteJSON(map[string]any{"res": "ok"}); err != nil {
 							return
 						}
 					}
 				}
+			}
+		case "ping":
+			s.mu.Lock()
+			s.pingCount++
+			shouldClose := s.closeAfterPing
+			s.mu.Unlock()
+			if err := conn.WriteJSON(map[string]any{"op": "pong"}); err != nil {
+				return
+			}
+			if shouldClose {
+				return
 			}
 		case "delete":
 			// delete is implemented as push with deleted:true in the actual protocol
@@ -347,9 +374,11 @@ func TestExecutePlan(t *testing.T) {
 	}
 
 	remote := make(map[string]model.FileRecord)
+	mock.mu.Lock()
 	for _, r := range mock.recordsByUID {
 		remote[r.Path] = r
 	}
+	mock.mu.Unlock()
 
 	e := &Engine{
 		Config: model.SyncConfig{VaultPath: vault},
@@ -384,7 +413,9 @@ func TestExecutePlan(t *testing.T) {
 	}
 
 	// Verify remote file was uploaded
+	mock.mu.Lock()
 	if len(mock.contentByUID) != 2 {
+		mock.mu.Unlock()
 		t.Fatalf("expected 2 remote records, got %d", len(mock.contentByUID))
 	}
 	foundLocal := false
@@ -394,6 +425,7 @@ func TestExecutePlan(t *testing.T) {
 			break
 		}
 	}
+	mock.mu.Unlock()
 	if !foundLocal {
 		t.Fatal("uploaded local content not found on mock server")
 	}


### PR DESCRIPTION
Closes #16

## Bug Description

The continuous sync client is experiencing periodic WebSocket disconnections:

```
ERR continuous: websocket read error error="websocket: close 1006 (abnormal closure): unexpected EOF"
INF continuous: readPump exited, reconnecting...
```

While an occasional disconnect is expected (e.g. server-side connection lifetime limits), after the **first** reconnect the client falls into a rapid reconnect/disconnect cycle (~every minute).

## Root Cause

In `src/internal/sync/continuous.go`, `startHeartbeat()` is called **once** during startup. The heartbeat goroutine contains:

```go
if conn == nil {
    return
}
```

When the WebSocket drops, the main loop sets `cs.conn = nil`. On the next ticker tick the heartbeat sees `conn == nil` and **returns permanently**. After reconnecting, the new connection has no keep-alive traffic, so any proxy/load balancer idle timeout (commonly 60 s) quickly kills it, causing the rapid cycle observed in the logs.

## Additional Issue

The reconnect loop uses a fixed 5 s backoff, which is too aggressive when the server is under load or rate-limiting.

## Changes

1. **Surviving heartbeat** – changed `return` to `continue` when `conn == nil` (and after a heartbeat timeout close) so the single heartbeat goroutine persists across reconnects. Also clears `cs.conn` inside the heartbeat on timeout to avoid double-close.
2. **Exponential backoff** – replaced fixed `5 s` delay with exponential backoff capped at `60 s`.
3. **Regression test** – added `TestContinuousHeartbeatAfterReconnect` and extended the mock server to support `ping`/`pong`, ensuring pings resume after a reconnect.

## Test Plan

```bash
cd src
go test ./internal/sync/ -run TestContinuous -v
```

All continuous sync tests pass, including the new reconnect/heartbeat test.

## Checklist

- [x] Code compiles (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] New test added for the specific bug
- [x] Follows Conventional Commits