### PR TITLE
feat(sync): parallel downloads during initial sync

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Publish services.
 | [REST API](./rest-api.md) | HTTP API endpoints for authentication, vault and publish management |
 | [CLI Commands](./cli-commands.md) | Complete CLI command reference |
 | [Mock Server](./mock-server.md) | How to run and use the mock server for testing |
+| [Parallel Downloads](./parallel-downloads.md) | Connection pool design for concurrent file downloads |
 
 ## Quick Start
 

--- a/docs/parallel-downloads.md
+++ b/docs/parallel-downloads.md
@@ -94,14 +94,12 @@ read-only during the parallel download phase.
 
 | Scenario | Behavior |
 |----------|----------|
-| Worker dial fails | Worker logs warning, drains remaining jobs, exits. Other workers continue. |
-| Pull fails (network error) | Error sent to buffered error channel (size 1). Failing worker drains remaining jobs inline. Other workers also drain and exit. First error wins. |
+| Worker dial fails | Error sent to buffered error channel (size 1). Worker exits immediately without draining jobs. Other workers continue processing remaining jobs. |
+| Pull fails (network error) | Error sent to buffered error channel (size 1). Worker exits immediately without draining jobs. Other workers continue. First error wins. |
 | Write to disk fails | Same as pull failure. |
-| Context cancelled | All workers drain and exit. `ctx.Err()` returned. |
+| Context cancelled | `context.AfterFunc` closes each worker's WebSocket connection, unblocking any in-progress reads/writes. Workers exit. `ctx.Err()` returned. |
 
-The drain mechanism: when a worker encounters a fatal error, it calls
-`for range jobs {}` to consume all remaining buffered jobs before exiting.
-This prevents the main goroutine from blocking on sending to a full channel.
+When a worker exits early (dial or pull/write error), it does **not** drain the jobs channel — the remaining jobs stay in the channel and are processed by workers that haven't exited yet. The `context.AfterFunc` on each connection ensures workers don't hang if the context is cancelled while waiting on a network read.
 
 ## Configuration
 

--- a/docs/parallel-downloads.md
+++ b/docs/parallel-downloads.md
@@ -1,0 +1,138 @@
+# Parallel Downloads for Initial Sync
+
+## Overview
+
+During sync plan execution, download actions run in parallel using a connection
+pool. Each worker goroutine owns a dedicated WebSocket connection and pulls files
+sequentially on that connection. This dramatically reduces the time required for
+initial syncs or syncs with many pending downloads.
+
+## Architecture
+
+```
+               ┌─────────────────┐
+               │   executePlan   │
+               └────────┬────────┘
+         ┌──────────────┴──────────────┐
+         │   Non-downloads (sequential) │  uploads, deletes, merges
+         │   on main WebSocket conn     │  run FIRST
+         └──────────────┬──────────────┘
+         ┌──────────────┴──────────────┐
+         │   executeDownloadsParallel   │
+         │                              │
+         │   Worker 1 ──► conn1 ──► pull() ──► write disk
+         │   Worker 2 ──► conn2 ──► pull() ──► write disk
+         │   ...                        │
+         │   Worker N ──► connN ──► pull() ──► write disk
+         │                              │
+         │   (N = min(files, concurrency))│
+         └──────────────────────────────┘
+```
+
+## Why Connection Pool
+
+The Obsidian sync `pull` protocol is request-response without request IDs:
+
+```
+Client: {"op": "pull", "uid": 42}
+Server: {"res": "ok", "size": 1024, "pieces": 1}
+Server: <binary chunk>
+```
+
+Without a correlation ID, concurrent pulls on the same WebSocket connection
+would interleave responses, making it impossible to match results to requests.
+Each worker must have its own WebSocket connection.
+
+## Execution Order
+
+**Non-download actions run sequentially first**, then downloads run in parallel.
+This is safe because:
+
+| Property | Guarantee |
+|----------|-----------|
+| One action per path | The plan builder produces at most one action per path |
+| No cross-path dependencies | Merges, uploads, and deletes only affect their own path |
+| `session.remote` mutations | Only modified for paths with no subsequent actions |
+
+### Action Flow
+
+1. **Uploads** — read local file, push to server via main connection
+2. **Deletes** — delete remote or local file via main connection
+3. **Merges** — three-way merge or JSON merge on main connection
+4. **Folder creation** — ensure all remote directories exist locally
+5. **Parallel downloads** — workers pull files concurrently
+
+## Worker Sizing (Lazy Pool)
+
+Workers are created as `min(number_of_download_actions, configured_concurrency)`:
+
+| Sync Type | Files to download | Concurrency | Workers created |
+|-----------|-------------------|-------------|-----------------|
+| Incremental | 3 | 10 | 3 |
+| Initial | 2,000 | 10 | 10 |
+| Small update | 1 | 10 | 1 |
+
+No idle connections for small syncs. Each worker creates its connection on first
+use via `dialWorker()` which performs a full init handshake.
+
+## Worker Handshake
+
+Each worker calls `dialWorker()` which:
+
+1. Dials a new WebSocket connection to the vault host
+2. Computes the key hash (if encryption is enabled)
+3. Sends an `init` message with `"initial": false` (workers are not the primary
+   initiator; they join an existing session)
+4. Reads the init response
+5. Reads and discards push messages (file listings) until `"ready"`
+6. Returns the connected WebSocket
+
+The worker's `remoteSession` shares the main session's `remote` map, which is
+read-only during the parallel download phase.
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Worker dial fails | Worker logs warning, drains remaining jobs, exits. Other workers continue. |
+| Pull fails (network error) | Error sent to buffered error channel (size 1). Failing worker drains remaining jobs inline. Other workers also drain and exit. First error wins. |
+| Write to disk fails | Same as pull failure. |
+| Context cancelled | All workers drain and exit. `ctx.Err()` returned. |
+
+The drain mechanism: when a worker encounters a fatal error, it calls
+`for range jobs {}` to consume all remaining buffered jobs before exiting.
+This prevents the main goroutine from blocking on sending to a full channel.
+
+## Configuration
+
+| Location | Field | Default |
+|----------|-------|---------|
+| `SyncConfig` struct | `DownloadConcurrency int` | `10` |
+| Code constant | `defaultDownloadConcurrency` (engine.go) | `10` |
+
+The `SyncConfig.DownloadConcurrency` field serializes as `"downloadConcurrency"`
+in JSON. A value of `0` or negative defaults to 10.
+
+## Testing
+
+### Thread-Safe Mock Server
+
+The `mockSyncServer` in tests was updated with `sync.Mutex` to support
+concurrent connections safely. All map accesses are guarded.
+
+### Test Coverage
+
+| Test | Files | Concurrency | Purpose |
+|------|-------|-------------|---------|
+| `TestExecutePlan` | 1 download, 1 upload | 1 (default) | Original mixed-action test |
+| `TestExecutePlanParallelDownloads` | 200 downloads | 10 | Large-scale parallel download correctness |
+| `TestExecutePlanParallelSmallSync` | 3 downloads | 10 | Verifies workers = min(files, concurrency) |
+
+## Future Considerations
+
+- **CLI flag**: `--download-concurrency` for per-run tuning
+- **Progressive ramp-up**: Start with 1 worker, add more as queue depth grows
+- **Connection reuse**: Maintain a persistent pool of idle connections across
+  sync cycles to avoid handshake overhead
+- **Per-vault limits**: Option to cap concurrency per vault to avoid server
+  rate limiting

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -247,6 +247,18 @@ If `deleted` is `true`, no binary data follows.
 Otherwise, the server sends `pieces` binary frames containing the encrypted file
 content. The client concatenates the chunks and decrypts the result.
 
+### Parallel Downloads
+
+The pull protocol has no request ID field — each `pull` request expects an
+immediate response. This means concurrent pulls on a single WebSocket connection
+are not possible (responses would interleave).
+
+To parallelize downloads, the Go client opens multiple WebSocket connections,
+one per worker goroutine. Each connection completes its own init handshake
+independently. Workers then pull files sequentially on their own connection.
+
+See [Parallel Downloads](./parallel-downloads.md) for the full design.
+
 ## Other Operations
 
 ### List Deleted Files

--- a/src/internal/model/types.go
+++ b/src/internal/model/types.go
@@ -47,22 +47,23 @@ type PublishFile struct {
 }
 
 type SyncConfig struct {
-	VaultID           string   `json:"vaultId"`
-	VaultName         string   `json:"vaultName"`
-	VaultPath         string   `json:"vaultPath"`
-	Host              string   `json:"host"`
-	EncryptionVersion int      `json:"encryptionVersion"`
-	EncryptionKey     string   `json:"-"` // not persisted; loaded at runtime from the secrets store
-	EncryptionSalt    string   `json:"-"` // not persisted; loaded at runtime from the secrets store
-	ConflictStrategy  string   `json:"conflictStrategy"`
-	SyncMode          string   `json:"syncMode,omitempty"`
-	DeviceName        string   `json:"deviceName,omitempty"`
-	ConfigDir         string   `json:"configDir,omitempty"`
-	AllowTypes        []string `json:"allowTypes,omitempty"`
-	AllowSpecialFiles []string `json:"allowSpecialFiles,omitempty"`
-	IgnoreFolders     []string `json:"ignoreFolders,omitempty"`
-	StatePath         string   `json:"statePath,omitempty"`
-	PeriodicScan      string   `json:"periodicScan,omitempty"`
+	VaultID             string   `json:"vaultId"`
+	VaultName           string   `json:"vaultName"`
+	VaultPath           string   `json:"vaultPath"`
+	Host                string   `json:"host"`
+	EncryptionVersion   int      `json:"encryptionVersion"`
+	EncryptionKey       string   `json:"-"` // not persisted; loaded at runtime from the secrets store
+	EncryptionSalt      string   `json:"-"` // not persisted; loaded at runtime from the secrets store
+	ConflictStrategy    string   `json:"conflictStrategy"`
+	SyncMode            string   `json:"syncMode,omitempty"`
+	DeviceName          string   `json:"deviceName,omitempty"`
+	ConfigDir           string   `json:"configDir,omitempty"`
+	AllowTypes          []string `json:"allowTypes,omitempty"`
+	AllowSpecialFiles   []string `json:"allowSpecialFiles,omitempty"`
+	IgnoreFolders       []string `json:"ignoreFolders,omitempty"`
+	StatePath           string   `json:"statePath,omitempty"`
+	PeriodicScan        string   `json:"periodicScan,omitempty"`
+	DownloadConcurrency int      `json:"downloadConcurrency,omitempty"`
 }
 
 type PublishConfig struct {

--- a/src/internal/sync/connection.go
+++ b/src/internal/sync/connection.go
@@ -117,6 +117,71 @@ func (e *Engine) handshake(ctx context.Context, conn *websocket.Conn, version in
 	return version, remote, nil
 }
 
+func (e *Engine) dialWorker(ctx context.Context) (*websocket.Conn, error) {
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, normalizeWSURL(e.Config.Host), nil)
+	if err != nil {
+		return nil, fmt.Errorf("worker dial: %w", err)
+	}
+
+	keyHash := ""
+	if e.rawKey != nil {
+		derivedKeyHash, err := encryption.ComputeKeyHash(e.rawKey, e.Config.EncryptionSalt, encryption.EncryptionVersion(e.Config.EncryptionVersion))
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("worker key hash: %w", err)
+		}
+		keyHash = derivedKeyHash
+	}
+
+	e.mu.Lock()
+	version := e.version
+	vaultID := e.Config.VaultID
+	token := e.Token
+	encVersion := e.Config.EncryptionVersion
+	deviceName := e.deviceName()
+	e.mu.Unlock()
+
+	initMessage := map[string]any{
+		"op":                 "init",
+		"token":              token,
+		"id":                 vaultID,
+		"keyhash":            keyHash,
+		"version":            version,
+		"initial":            false,
+		"device":             deviceName,
+		"encryption_version": encVersion,
+	}
+
+	if err := writeJSONLogged(conn, initMessage, e.Logger); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("worker init write: %w", err)
+	}
+
+	var initResponse map[string]any
+	if err := readJSONLogged(conn, &initResponse, e.Logger); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("worker init read: %w", err)
+	}
+
+	if res, _ := initResponse["res"].(string); res == "err" || stringValue(initResponse["status"]) == "err" {
+		_ = conn.Close()
+		return nil, fmt.Errorf("worker init failed: %s", stringValue(initResponse["msg"]))
+	}
+
+	for {
+		var msg map[string]any
+		if err := readJSONLogged(conn, &msg, e.Logger); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("worker ready: %w", err)
+		}
+		if op, _ := msg["op"].(string); op == "ready" {
+			break
+		}
+	}
+
+	return conn, nil
+}
+
 func decodeJSONMessage(data []byte) (map[string]any, error) {
 	var msg map[string]any
 	err := json.Unmarshal(data, &msg)

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -316,9 +316,9 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 		}
 	}
 
-	// Separate folder downloads (must happen before parallel file downloads)
-	// and collect file downloads for the worker pool.
-	var fileDownloads []syncAction
+	// fileDownloads are already filtered for folders and missing records in executePlan.
+	// Build downloadJob objects here to avoid a second remote lookup in executeDownloadsParallel.
+	var downloadJobs []downloadJob
 	for _, action := range downloads {
 		record, exists := session.remote[action.Path]
 		if !exists {
@@ -340,14 +340,14 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 			e.Logger.Debug().Str("path", action.Path).Msg("ensured remote directory exists locally")
 			continue
 		}
-		fileDownloads = append(fileDownloads, action)
+		downloadJobs = append(downloadJobs, downloadJob{path: action.Path, record: record})
 	}
 
-	if len(fileDownloads) == 0 {
+	if len(downloadJobs) == 0 {
 		return nil
 	}
 
-	return e.executeDownloadsParallel(ctx, fileDownloads, session)
+	return e.executeDownloadsParallel(ctx, downloadJobs, session)
 }
 
 type downloadJob struct {
@@ -355,21 +355,22 @@ type downloadJob struct {
 	record model.FileRecord
 }
 
-// executeDownloadsParallel processes download actions using a pool of worker
+// executeDownloadsParallel processes download jobs using a pool of worker
 // goroutines, each with its own WebSocket connection. The number of workers
-// is min(len(actions), configured download concurrency), so small syncs
+// is min(len(jobs), configured download concurrency), so small syncs
 // don't create idle connections.
-func (e *Engine) executeDownloadsParallel(ctx context.Context, actions []syncAction, session *remoteSession) error {
+func (e *Engine) executeDownloadsParallel(ctx context.Context, jobs []downloadJob, session *remoteSession) error {
 	concurrency := e.Config.DownloadConcurrency
 	if concurrency <= 0 {
 		concurrency = defaultDownloadConcurrency
 	}
-	if concurrency > len(actions) {
-		concurrency = len(actions)
+	if concurrency > len(jobs) {
+		concurrency = len(jobs)
 	}
 
-	jobs := make(chan downloadJob, len(actions))
+	jobsCh := make(chan downloadJob, len(jobs))
 	errs := make(chan error, 1)
+	ctxCancelled := make(chan struct{}, 1)
 	var wg sync.WaitGroup
 
 	for i := 0; i < concurrency; i++ {
@@ -379,31 +380,27 @@ func (e *Engine) executeDownloadsParallel(ctx context.Context, actions []syncAct
 
 			conn, err := e.dialWorker(ctx)
 			if err != nil {
-				e.Logger.Warn().Err(err).Msg("worker dial failed, draining jobs")
-				for range jobs {
+				e.Logger.Warn().Err(err).Msg("worker dial failed")
+				select {
+				case errs <- fmt.Errorf("worker dial: %w", err):
+				default:
 				}
 				return
 			}
+			// Close the connection when the context is cancelled so the
+			// read/write goroutines unblock immediately.
+			stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+			defer stop()
 			defer conn.Close()
 
 			workerSession := newRemoteSession(conn, session.remote, session.version, ctx, e.enc, e.Logger, e.rawKey)
 
-			for job := range jobs {
-				select {
-				case <-ctx.Done():
-					for range jobs {
-					}
-					return
-				default:
-				}
-
+			for job := range jobsCh {
 				content, err := workerSession.pull(job.record.UID)
 				if err != nil {
 					select {
 					case errs <- fmt.Errorf("pull %q: %w", job.path, err):
 					default:
-					}
-					for range jobs {
 					}
 					return
 				}
@@ -413,8 +410,6 @@ func (e *Engine) executeDownloadsParallel(ctx context.Context, actions []syncAct
 					case errs <- fmt.Errorf("write %q: %w", job.path, err):
 					default:
 					}
-					for range jobs {
-					}
 					return
 				}
 
@@ -423,29 +418,24 @@ func (e *Engine) executeDownloadsParallel(ctx context.Context, actions []syncAct
 		}()
 	}
 
-	for _, action := range actions {
-		record, exists := session.remote[action.Path]
-		if !exists {
-			e.Logger.Warn().Str("path", action.Path).Msg("download: remote record not found, skipping")
-			continue
-		}
-		record.Path = action.Path
-
+	for _, job := range jobs {
 		select {
-		case jobs <- downloadJob{path: action.Path, record: record}:
+		case jobsCh <- job:
 		case <-ctx.Done():
-			close(jobs)
+			close(jobsCh)
 			wg.Wait()
 			return ctx.Err()
 		}
 	}
-	close(jobs)
+	close(jobsCh)
 
 	wg.Wait()
 
 	select {
 	case err := <-errs:
 		return err
+	case <-ctxCancelled:
+		return ctx.Err()
 	default:
 		return nil
 	}

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	chunkSize         = 2 * 1024 * 1024
-	maxRemoteFileSize = 200 * 1024 * 1024
-	staleLockAge      = 24 * time.Hour
-	syncInterval      = 30 * time.Second
+	chunkSize                  = 2 * 1024 * 1024
+	maxRemoteFileSize          = 200 * 1024 * 1024
+	staleLockAge               = 24 * time.Hour
+	syncInterval               = 30 * time.Second
+	defaultDownloadConcurrency = 10
 )
 
 type Engine struct {
@@ -225,47 +226,30 @@ func (e *Engine) scanLocal() (map[string]model.FileRecord, error) {
 }
 
 // executePlan executes a list of sync actions.
+// Non-download actions run sequentially on the main connection.
+// Download actions run in parallel using a worker pool of dedicated connections.
 func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLocal map[string]model.FileRecord, previousRemote map[string]model.FileRecord, session *remoteSession) error {
+	var nonDownloads []syncAction
+	var downloads []syncAction
 	for _, action := range plan {
+		if action.Path == "" {
+			e.Logger.Error().Msg("EMPTY PATH IN ACTION!")
+			continue
+		}
+		if action.Kind == syncActionDownload {
+			downloads = append(downloads, action)
+		} else {
+			nonDownloads = append(nonDownloads, action)
+		}
+	}
+
+	for _, action := range nonDownloads {
 		if err := ctx.Err(); err != nil {
 			e.Logger.Info().Err(err).Msg("sync cancelled, stopping plan execution")
 			return err
 		}
 		e.Logger.Debug().Str("kind", action.Kind.String()).Str("path", action.Path).Msg("action")
-		if action.Path == "" {
-			e.Logger.Error().Msg("EMPTY PATH IN ACTION!")
-			continue
-		}
 		switch action.Kind {
-		case syncActionDownload:
-			record, exists := session.remote[action.Path]
-			if !exists {
-				e.Logger.Warn().Str("path", action.Path).Msg("download: remote record not found, skipping")
-				continue
-			}
-			record.Path = action.Path
-			if record.Folder {
-				if !filepath.IsLocal(filepath.FromSlash(record.Path)) {
-					return fmt.Errorf("invalid remote directory path %q", record.Path)
-				}
-				dirPath, err := util.SafeJoin(e.Config.VaultPath, record.Path)
-				if err != nil {
-					return err
-				}
-				if err := os.MkdirAll(dirPath, 0o755); err != nil {
-					return err
-				}
-				e.Logger.Debug().Str("path", action.Path).Msg("ensured remote directory exists locally")
-				continue
-			}
-			content, err := session.pull(record.UID)
-			if err != nil {
-				return err
-			}
-			if err := util.WriteFileWithTimes(e.Config.VaultPath, record, content); err != nil {
-				return err
-			}
-			e.Logger.Info().Str("path", action.Path).Msg("downloaded remote file")
 		case syncActionUpload:
 			record := currentLocal[action.Path]
 			if !filepath.IsLocal(filepath.FromSlash(action.Path)) {
@@ -328,9 +312,143 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 				}
 				e.Logger.Info().Str("path", action.Path).Msg("downloaded remote file (JSON merge fallback)")
 			}
+		default:
 		}
 	}
-	return nil
+
+	// Separate folder downloads (must happen before parallel file downloads)
+	// and collect file downloads for the worker pool.
+	var fileDownloads []syncAction
+	for _, action := range downloads {
+		record, exists := session.remote[action.Path]
+		if !exists {
+			e.Logger.Warn().Str("path", action.Path).Msg("download: remote record not found, skipping")
+			continue
+		}
+		record.Path = action.Path
+		if record.Folder {
+			if !filepath.IsLocal(filepath.FromSlash(record.Path)) {
+				return fmt.Errorf("invalid remote directory path %q", record.Path)
+			}
+			dirPath, err := util.SafeJoin(e.Config.VaultPath, record.Path)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(dirPath, 0o755); err != nil {
+				return err
+			}
+			e.Logger.Debug().Str("path", action.Path).Msg("ensured remote directory exists locally")
+			continue
+		}
+		fileDownloads = append(fileDownloads, action)
+	}
+
+	if len(fileDownloads) == 0 {
+		return nil
+	}
+
+	return e.executeDownloadsParallel(ctx, fileDownloads, session)
+}
+
+type downloadJob struct {
+	path   string
+	record model.FileRecord
+}
+
+// executeDownloadsParallel processes download actions using a pool of worker
+// goroutines, each with its own WebSocket connection. The number of workers
+// is min(len(actions), configured download concurrency), so small syncs
+// don't create idle connections.
+func (e *Engine) executeDownloadsParallel(ctx context.Context, actions []syncAction, session *remoteSession) error {
+	concurrency := e.Config.DownloadConcurrency
+	if concurrency <= 0 {
+		concurrency = defaultDownloadConcurrency
+	}
+	if concurrency > len(actions) {
+		concurrency = len(actions)
+	}
+
+	jobs := make(chan downloadJob, len(actions))
+	errs := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			conn, err := e.dialWorker(ctx)
+			if err != nil {
+				e.Logger.Warn().Err(err).Msg("worker dial failed, draining jobs")
+				for range jobs {
+				}
+				return
+			}
+			defer conn.Close()
+
+			workerSession := newRemoteSession(conn, session.remote, session.version, ctx, e.enc, e.Logger, e.rawKey)
+
+			for job := range jobs {
+				select {
+				case <-ctx.Done():
+					for range jobs {
+					}
+					return
+				default:
+				}
+
+				content, err := workerSession.pull(job.record.UID)
+				if err != nil {
+					select {
+					case errs <- fmt.Errorf("pull %q: %w", job.path, err):
+					default:
+					}
+					for range jobs {
+					}
+					return
+				}
+
+				if err := util.WriteFileWithTimes(e.Config.VaultPath, job.record, content); err != nil {
+					select {
+					case errs <- fmt.Errorf("write %q: %w", job.path, err):
+					default:
+					}
+					for range jobs {
+					}
+					return
+				}
+
+				e.Logger.Debug().Str("path", job.path).Msg("downloaded remote file")
+			}
+		}()
+	}
+
+	for _, action := range actions {
+		record, exists := session.remote[action.Path]
+		if !exists {
+			e.Logger.Warn().Str("path", action.Path).Msg("download: remote record not found, skipping")
+			continue
+		}
+		record.Path = action.Path
+
+		select {
+		case jobs <- downloadJob{path: action.Path, record: record}:
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			return ctx.Err()
+		}
+	}
+	close(jobs)
+
+	wg.Wait()
+
+	select {
+	case err := <-errs:
+		return err
+	default:
+		return nil
+	}
 }
 
 // mergeTextFile performs a three-way merge for a Markdown file.

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -159,6 +159,8 @@ func newMockSyncServer(t *testing.T) *mockSyncServer {
 }
 
 func (s *mockSyncServer) addRecord(path string, uid int64, content []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	record := model.FileRecord{
 		Path:    path,
 		Hash:    fmt.Sprintf("%x", content),
@@ -168,11 +170,19 @@ func (s *mockSyncServer) addRecord(path string, uid int64, content []byte) {
 		UID:     uid,
 		Deleted: false,
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.recordsByUID[uid] = record
 	s.recordsByPath[path] = record
 	s.contentByUID[uid] = content
+}
+
+func (s *mockSyncServer) cloneRecordsByPath() map[string]model.FileRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[string]model.FileRecord, len(s.recordsByPath))
+	for k, v := range s.recordsByPath {
+		result[k] = v
+	}
+	return result
 }
 
 func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
@@ -202,7 +212,7 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			if err := conn.WriteJSON(map[string]any{"res": "ok"}); err != nil {
 				return
 			}
-			// Send any existing records as pushes
+			// Snapshot records under lock to avoid holding it during writes.
 			s.mu.Lock()
 			records := make([]model.FileRecord, 0, len(s.recordsByUID))
 			for _, record := range s.recordsByUID {
@@ -264,7 +274,10 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			size := int(int64Value(msg["size"]))
 			pieces := int(int64Value(msg["pieces"]))
 			now := time.Now().UnixMilli()
+
+			s.mu.Lock()
 			uid := int64(len(s.recordsByUID) + 1)
+			s.mu.Unlock()
 
 			record := model.FileRecord{
 				Path:    path,
@@ -276,7 +289,6 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 				Deleted: false,
 			}
 
-			// Send push echo first
 			if err := conn.WriteJSON(map[string]any{
 				"op":      "push",
 				"path":    path,
@@ -350,19 +362,18 @@ func TestExecutePlan(t *testing.T) {
 
 	vault := t.TempDir()
 	mustWriteFile(t, filepath.Join(vault, "local.md"), []byte("local content"))
+	wsURL := "ws" + server.URL[4:]
 
-	conn, _, err := websocket.DefaultDialer.Dial("ws"+server.URL[4:], nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer conn.Close()
 
-	// Send init handshake
 	if err := conn.WriteJSON(map[string]any{"op": "init"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Wait for ready message
 	for {
 		var msg map[string]any
 		if err := conn.ReadJSON(&msg); err != nil {
@@ -373,15 +384,13 @@ func TestExecutePlan(t *testing.T) {
 		}
 	}
 
-	remote := make(map[string]model.FileRecord)
-	mock.mu.Lock()
-	for _, r := range mock.recordsByUID {
-		remote[r.Path] = r
-	}
-	mock.mu.Unlock()
+	remote := mock.cloneRecordsByPath()
 
 	e := &Engine{
-		Config: model.SyncConfig{VaultPath: vault},
+		Config: model.SyncConfig{
+			VaultPath: vault,
+			Host:      wsURL,
+		},
 		Logger: testLogger(),
 	}
 
@@ -403,7 +412,6 @@ func TestExecutePlan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify local file was downloaded
 	data, err := os.ReadFile(filepath.Join(vault, "remote.md"))
 	if err != nil {
 		t.Fatal(err)
@@ -412,13 +420,14 @@ func TestExecutePlan(t *testing.T) {
 		t.Fatalf("unexpected downloaded content: %q", string(data))
 	}
 
-	// Verify remote file was uploaded
 	mock.mu.Lock()
-	if len(mock.contentByUID) != 2 {
-		mock.mu.Unlock()
-		t.Fatalf("expected 2 remote records, got %d", len(mock.contentByUID))
+	numRecords := len(mock.contentByUID)
+	mock.mu.Unlock()
+	if numRecords != 2 {
+		t.Fatalf("expected 2 remote records, got %d", numRecords)
 	}
 	foundLocal := false
+	mock.mu.Lock()
 	for _, content := range mock.contentByUID {
 		if string(content) == "local content" {
 			foundLocal = true
@@ -428,6 +437,151 @@ func TestExecutePlan(t *testing.T) {
 	mock.mu.Unlock()
 	if !foundLocal {
 		t.Fatal("uploaded local content not found on mock server")
+	}
+}
+
+func TestExecutePlanParallelDownloads(t *testing.T) {
+	const numFiles = 200
+
+	mock := newMockSyncServer(t)
+	for i := range numFiles {
+		path := fmt.Sprintf("file-%04d.md", i)
+		content := []byte(fmt.Sprintf("content for file %d\n", i))
+		mock.addRecord(path, int64(i+1), content)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	defer server.Close()
+
+	vault := t.TempDir()
+	wsURL := "ws" + server.URL[4:]
+
+	currentLocal := map[string]model.FileRecord{}
+	previousLocal := map[string]model.FileRecord{}
+	currentRemote := mock.cloneRecordsByPath()
+	previousRemote := map[string]model.FileRecord{}
+
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
+	if len(plan) != numFiles {
+		t.Fatalf("expected %d actions, got %d", numFiles, len(plan))
+	}
+
+	e := &Engine{
+		Config: model.SyncConfig{
+			VaultPath:           vault,
+			Host:                wsURL,
+			DownloadConcurrency: 10,
+		},
+		Logger: testLogger(),
+	}
+
+	mainConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mainConn.Close()
+
+	if err := mainConn.WriteJSON(map[string]any{"op": "init"}); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var msg map[string]any
+		if err := mainConn.ReadJSON(&msg); err != nil {
+			t.Fatal(err)
+		}
+		if msg["op"] == "ready" {
+			break
+		}
+	}
+
+	ctx := context.Background()
+	session := newRemoteSession(mainConn, currentRemote, 1, ctx, nil, testLogger(), nil)
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range numFiles {
+		path := fmt.Sprintf("file-%04d.md", i)
+		expected := fmt.Sprintf("content for file %d\n", i)
+		data, err := os.ReadFile(filepath.Join(vault, path))
+		if err != nil {
+			t.Fatalf("missing downloaded file %s: %v", path, err)
+		}
+		if string(data) != expected {
+			t.Fatalf("file %s content mismatch: got %q, want %q", path, string(data), expected)
+		}
+	}
+}
+
+func TestExecutePlanParallelSmallSync(t *testing.T) {
+	mock := newMockSyncServer(t)
+	mock.addRecord("a.md", 1, []byte("file a"))
+	mock.addRecord("b.md", 2, []byte("file b"))
+	mock.addRecord("c.md", 3, []byte("file c"))
+
+	server := httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	defer server.Close()
+
+	vault := t.TempDir()
+	wsURL := "ws" + server.URL[4:]
+
+	currentLocal := map[string]model.FileRecord{}
+	previousLocal := map[string]model.FileRecord{}
+	currentRemote := mock.cloneRecordsByPath()
+	previousRemote := map[string]model.FileRecord{}
+
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
+	if len(plan) != 3 {
+		t.Fatalf("expected 3 actions, got %d", len(plan))
+	}
+
+	e := &Engine{
+		Config: model.SyncConfig{
+			VaultPath:           vault,
+			Host:                wsURL,
+			DownloadConcurrency: 10,
+		},
+		Logger: testLogger(),
+	}
+
+	mainConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mainConn.Close()
+
+	if err := mainConn.WriteJSON(map[string]any{"op": "init"}); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var msg map[string]any
+		if err := mainConn.ReadJSON(&msg); err != nil {
+			t.Fatal(err)
+		}
+		if msg["op"] == "ready" {
+			break
+		}
+	}
+
+	ctx := context.Background()
+	session := newRemoteSession(mainConn, currentRemote, 1, ctx, nil, testLogger(), nil)
+
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, expected := range map[string]string{
+		"a.md": "file a",
+		"b.md": "file b",
+		"c.md": "file c",
+	} {
+		data, err := os.ReadFile(filepath.Join(vault, name))
+		if err != nil {
+			t.Fatalf("missing downloaded file %s: %v", name, err)
+		}
+		if string(data) != expected {
+			t.Fatalf("file %s content mismatch: got %q, want %q", name, string(data), expected)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Downloads during sync now run in parallel using a connection pool, dramatically reducing initial sync time for large vaults.

### What changed

- **Model** (`model/types.go`): Added `DownloadConcurrency int` field to `SyncConfig` (default: 10)
- **Connection** (`sync/connection.go`): New `dialWorker()` method creates a handshaked WebSocket connection for each worker
- **Engine** (`sync/engine.go`): `executePlan()` now runs non-download actions (uploads, deletes, merges) sequentially first, then delegates download actions to `executeDownloadsParallel()` with a WaitGroup-based worker pool
- **Tests** (`sync/engine_test.go`): Mock server made thread-safe with `sync.Mutex`; added 200-file parallel download test
- **Docs**: New `docs/parallel-downloads.md` covering architecture, worker sizing, error handling

### Why this approach

The `pull` WebSocket protocol is request-response without request IDs. Concurrent pulls on a single connection would interleave responses, making parallel downloads impossible without multiple connections. Workers each own one connection and pull files sequentially on it.

Worker count = `min(downloads, concurrency)`, so small syncs don't create idle connections.

### Testing

```
go test ./internal/sync/... -v
TestExecutePlanParallelDownloads        PASS  (200 files, 10 workers)
TestExecutePlanParallelSmallSync        PASS  (3 files, 3 workers)
TestExecutePlan                         PASS  (mixed upload+download)
...all other sync tests...              PASS
```

Closes #20