### PR TITLE
feat: add systemd template unit for continuous sync mode

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,7 +162,6 @@ nfpms:
         dst: /usr/share/doc/obsidian-headless/README.md
       - src: ./build/obsidian-headless-sync@.service
         dst: /usr/lib/systemd/user/obsidian-headless-sync@.service
-        type: config
 
 # Homebrew Cask - pushes to Belphemur/homebrew-tap
 # https://goreleaser.com/customization/publish/homebrew_casks/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -160,6 +160,9 @@ nfpms:
         dst: /usr/share/doc/obsidian-headless/LICENSE
       - src: ./README.md
         dst: /usr/share/doc/obsidian-headless/README.md
+      - src: ./build/obsidian-headless-sync@.service
+        dst: /usr/lib/systemd/user/obsidian-headless-sync@.service
+        type: config
 
 # Homebrew Cask - pushes to Belphemur/homebrew-tap
 # https://goreleaser.com/customization/publish/homebrew_casks/

--- a/build/obsidian-headless-sync@.service
+++ b/build/obsidian-headless-sync@.service
@@ -1,0 +1,94 @@
+# obsidian-headless-sync@.service — Systemd template unit for Obsidian Headless continuous sync
+#
+# WHAT THIS SERVICE DOES:
+#   This template runs `ob sync --continuous --path <VAULT_PATH>` as a managed
+#   systemd service. The continuous mode keeps your Obsidian vault in sync
+#   indefinitely using WebSocket real-time updates and local fsnotify watchers.
+#
+#   The instance name (`%I`) is the unescaped vault path. For example, enabling
+#   the instance `obsidian-headless-sync@/home/user/vault.service` will sync
+#   `/home/user/vault` continuously.
+#
+# HOW TO INSTALL:
+#   The package installs this file to /usr/lib/systemd/user/, so systemd
+#   discovers it automatically. No manual copying is needed if installed
+#   via .deb, .rpm, .apk, or .archlinux package.
+#
+#   Manual installation (no package manager):
+#   As a USER service (per-user, no root required):
+#     cp obsidian-headless-sync@.service ~/.config/systemd/user/
+#     systemctl --user daemon-reload
+#
+#   As a SYSTEM service (machine-wide, requires root):
+#     sudo cp obsidian-headless-sync@.service /etc/systemd/system/
+#     sudo systemctl daemon-reload
+#
+# HOW TO ENABLE & START:
+#   Replace `/path/to/vault` with the absolute path to your Obsidian vault.
+#
+#   User service:
+#     systemctl --user enable --now "obsidian-headless-sync@/path/to/vault.service"
+#
+#   System service:
+#     sudo systemctl enable --now "obsidian-headless-sync@/path/to/vault.service"
+#
+# HOW TO CHECK STATUS:
+#   User service:
+#     systemctl --user status "obsidian-headless-sync@/path/to/vault.service"
+#
+#   System service:
+#     sudo systemctl status "obsidian-headless-sync@/path/to/vault.service"
+#
+# HOW TO VIEW LOGS:
+#   User service:
+#     journalctl --user -u "obsidian-headless-sync@/path/to/vault.service" -f
+#
+#   System service:
+#     sudo journalctl -u "obsidian-headless-sync@/path/to/vault.service" -f
+#
+# DOCUMENTATION:
+#   Project:      https://github.com/Belphemur/obsidian-headless
+#   Config dir:   ~/.config/obsidian-headless/
+#   Binary path:  /usr/local/bin/ob
+
+[Unit]
+Description=Obsidian Headless continuous sync for vault %I
+Documentation=https://github.com/Belphemur/obsidian-headless
+
+# Ensure the network is up before starting, since sync requires WebSocket connectivity
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# The process runs indefinitely in continuous mode
+Type=simple
+
+# Fail fast if the vault path doesn't exist (mirrors s6-overlay behavior)
+ExecStartPre=/bin/test -d %I
+
+# Start the Obsidian Headless sync daemon for the given vault path
+ExecStart=/usr/local/bin/ob sync --continuous --path %I
+
+# Run from the vault directory so relative paths resolve correctly
+WorkingDirectory=%I
+
+# Restart policy: only restart on unclean exits (crashes), not on clean exits
+Restart=on-failure
+RestartSec=10s
+
+# Rate-limit restarts to prevent restart loops
+StartLimitBurst=5
+StartLimitInterval=120s
+
+# Optional system-service hardening (uncomment for systemd system services):
+# NoNewPrivileges=yes
+# PrivateTmp=yes
+# ProtectSystem=strict
+# ProtectHome=read-only
+# ReadWritePaths=%I
+# ReadWritePaths=%h/.config/obsidian-headless
+
+[Install]
+# Bind to the default target so the service starts automatically on boot (system)
+# or user session start (user)
+WantedBy=default.target

--- a/build/obsidian-headless-sync@.service
+++ b/build/obsidian-headless-sync@.service
@@ -5,9 +5,10 @@
 #   systemd service. The continuous mode keeps your Obsidian vault in sync
 #   indefinitely using WebSocket real-time updates and local fsnotify watchers.
 #
-#   The instance name (`%I`) is the unescaped vault path. For example, enabling
-#   the instance `obsidian-headless-sync@/home/user/vault.service` will sync
-#   `/home/user/vault` continuously.
+#   The instance name is the vault path escaped with systemd-escape(1):
+#     systemd-escape --path /home/user/vault   →   home-user-vault
+#   Then enable: obsidian-headless-sync@home-user-vault.service
+#   Inside the unit, %I unescapes back to the real path (/home/user/vault).
 #
 # HOW TO INSTALL:
 #   The package installs this file to /usr/lib/systemd/user/, so systemd
@@ -24,32 +25,33 @@
 #     sudo systemctl daemon-reload
 #
 # HOW TO ENABLE & START:
-#   Replace `/path/to/vault` with the absolute path to your Obsidian vault.
+#   First, escape your vault path:
+#     systemd-escape --path /path/to/vault   # gives path-to-vault
 #
 #   User service:
-#     systemctl --user enable --now "obsidian-headless-sync@/path/to/vault.service"
+#     systemctl --user enable --now obsidian-headless-sync@path-to-vault.service
 #
 #   System service:
-#     sudo systemctl enable --now "obsidian-headless-sync@/path/to/vault.service"
+#     sudo systemctl enable --now obsidian-headless-sync@path-to-vault.service
 #
 # HOW TO CHECK STATUS:
 #   User service:
-#     systemctl --user status "obsidian-headless-sync@/path/to/vault.service"
+#     systemctl --user status obsidian-headless-sync@path-to-vault.service
 #
 #   System service:
-#     sudo systemctl status "obsidian-headless-sync@/path/to/vault.service"
+#     sudo systemctl status obsidian-headless-sync@path-to-vault.service
 #
 # HOW TO VIEW LOGS:
 #   User service:
-#     journalctl --user -u "obsidian-headless-sync@/path/to/vault.service" -f
+#     journalctl --user -u obsidian-headless-sync@path-to-vault.service -f
 #
 #   System service:
-#     sudo journalctl -u "obsidian-headless-sync@/path/to/vault.service" -f
+#     sudo journalctl -u obsidian-headless-sync@path-to-vault.service -f
 #
 # DOCUMENTATION:
 #   Project:      https://github.com/Belphemur/obsidian-headless
 #   Config dir:   ~/.config/obsidian-headless/
-#   Binary path:  /usr/local/bin/ob
+#   Binary path:  /usr/bin/ob
 
 [Unit]
 Description=Obsidian Headless continuous sync for vault %I
@@ -59,34 +61,35 @@ Documentation=https://github.com/Belphemur/obsidian-headless
 After=network-online.target
 Wants=network-online.target
 
+# Rate-limit restarts to prevent restart loops
+StartLimitBurst=5
+StartLimitIntervalSec=120s
+
 [Service]
 # The process runs indefinitely in continuous mode
 Type=simple
 
 # Fail fast if the vault path doesn't exist (mirrors s6-overlay behavior)
-ExecStartPre=/bin/test -d %I
+ExecStartPre=/bin/test -d "%I"
 
 # Start the Obsidian Headless sync daemon for the given vault path
-ExecStart=/usr/local/bin/ob sync --continuous --path %I
+ExecStart=/usr/bin/ob sync --continuous --path "%I"
 
 # Run from the vault directory so relative paths resolve correctly
-WorkingDirectory=%I
+WorkingDirectory="%I"
 
 # Restart policy: only restart on unclean exits (crashes), not on clean exits
 Restart=on-failure
 RestartSec=10s
 
-# Rate-limit restarts to prevent restart loops
-StartLimitBurst=5
-StartLimitInterval=120s
-
 # Optional system-service hardening (uncomment for systemd system services):
 # NoNewPrivileges=yes
 # PrivateTmp=yes
+# Network access is required — do NOT enable PrivateNetwork=yes
 # ProtectSystem=strict
 # ProtectHome=read-only
-# ReadWritePaths=%I
-# ReadWritePaths=%h/.config/obsidian-headless
+# ReadWritePaths="%I"
+# ReadWritePaths="%h/.config/obsidian-headless"
 
 [Install]
 # Bind to the default target so the service starts automatically on boot (system)


### PR DESCRIPTION
## Summary

Adds `obsidian-headless-sync@.service` — a systemd template unit that runs `ob sync --continuous --path <vault_path>` as a managed service. This is the native Linux equivalent of the existing s6-overlay Docker supervision.

## What's Included

### `build/obsidian-headless-sync@.service`
- **Template unit** — instance name `%I` is the vault path (e.g., `systemctl --user enable obsidian-headless-sync@/home/user/vault.service`)
- **Fail Fast** — `ExecStartPre=/bin/test -d %I` halts immediately if vault doesn't exist (mirrors s6-overlay behavior)
- **Auto-restart** — `Restart=on-failure` with `RestartSec=10s` and `StartLimitBurst=5` rate-limiting
- **Works as both user and system service** — ships to `/usr/lib/systemd/user/` with `WantedBy=default.target`
- **Comprehensive header docs** — install, enable, start, status, and log commands for both user/system contexts
- **Optional security hardening** — commented directives for system service use

### `.goreleaser.yml`
- Added unit file to `nfpms.contents` with `type: config`
- Destination: `/usr/lib/systemd/user/obsidian-headless-sync@.service`
- Ships in `.deb`, `.rpm`, `.apk`, and `.archlinux` packages

## Design Decisions

| Decision | Rationale |
|---|---|
| `%I` (unescaped) for vault path | Supports `/` in paths naturally |
| `Type=simple` not `notify` | No sd_notify needed for v1 |
| `ExecStartPre=/bin/test` not `/usr/bin/test` | Alpine/BusyBox cross-distro compatibility |
| `WantedBy=default.target` | Works for both `--user` and system services |
| Template units (`@.service`) are inert until enabled | Safe to ship in `/usr/lib/systemd/user/`; no auto-start risk |