### PR TITLE
docs(usage): fix sync command reference — sync-run→sync, add missing --path flag

### DIFF
--- a/website/src/usage/sync.md
+++ b/website/src/usage/sync.md
@@ -54,7 +54,7 @@ ob sync-setup --vault <vault> [--path <path>] [--password <password>] [flags]
 | `--password` | | Encryption password (prompts for encrypted vaults) |
 | `--device-name` | | Device name |
 | `--config-dir` | `.obsidian` | Config directory |
-| `--state-path` | | Custom state database path |
+| `--state-path` | | Custom state database path (default: `~/.config/obsidian-headless/sync/{vaultID}/state.db`) |
 | `--periodic-scan` | `1h` | Periodic full rescan interval (e.g. `60s`, `5m`, `1h`); set to `0` to disable |
 
 ## `ob sync-config`
@@ -75,7 +75,7 @@ ob sync-config [--path <path>] [--mode <mode>] [--conflict-strategy <strategy>] 
 | `--configs` | | Comma-separated config categories to allow |
 | `--device-name` | | Device name |
 | `--config-dir` | `.obsidian` | Config directory |
-| `--state-path` | | Custom state database path |
+| `--state-path` | | Custom state database path (default: `~/.config/obsidian-headless/sync/{vaultID}/state.db`) |
 | `--periodic-scan` | | Periodic full rescan interval (e.g. `60s`, `5m`, `1h`); set to `0` to disable |
 
 When called without any update flags, displays the current configuration.
@@ -104,14 +104,15 @@ ob sync-unlink [--path <path>]
 |------|---------|-------------|
 | `--path` | `.` | Local vault path |
 
-## `ob sync-run`
+## `ob sync`
 
 Run sync for a configured vault.
 
 ```bash
-ob sync-run [<selector>] [--continuous]
+ob sync [--path <path>] [--continuous]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--path` | `.` | Local vault path |
 | `--continuous` | `false` | Run continuously (watch for changes) |


### PR DESCRIPTION
## Summary

Fixes inaccurate CLI command documentation in `website/src/usage/sync.md` by cross-referencing against the actual CLI implementation in `src/internal/cli/sync.go`.

## Changes

### Critical fixes
- **`ob sync-run` → `ob sync`**: The actual subcommand is `sync`, not `sync-run` (ref: `sync.go:376`, `Use: "sync"`)
- **Removed fake positional `[<selector>]` arg**: The command uses `--path` flag, not a positional argument (ref: `sync.go:425`)
- **Added missing `--path` flag**: `ob sync` accepts `--path` (default `.`) — was absent from docs

### Minor improvements
- Expanded `--state-path` descriptions for both `sync-setup` and `sync-config` to include the full default path: `~/.config/obsidian-headless/sync/{vaultID}/state.db` (ref: `sync.go:223`, `sync.go:325`)

### Verified accurate (no changes needed)
- `publish.md` — all 6 commands verified against `publish.go`
- `authentication.md` — all global flags and login parameters verified against `root.go` and `auth.go`
- `configuration.md` — vault/site selection rules match code