### PR TITLE
feat: add third-party disclaimer to login and website

### DIFF
--- a/src/cmd/ob-go/e2e_test.go
+++ b/src/cmd/ob-go/e2e_test.go
@@ -89,7 +89,7 @@ func TestE2E_LoginAndListRemote(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 	t.Setenv("OBSIDIAN_API_BASE", apiBase)
 
-	output := runCLI(t, "login", "--email", "test@example.com", "--password", "test")
+	output := runCLI(t, "login", "--email", "test@example.com", "--password", "test", "--accept-disclaimer")
 	assert.Contains(t, output, "Login successful")
 
 	output = runCLI(t, "sync-list-remote")

--- a/src/internal/cli/auth.go
+++ b/src/internal/cli/auth.go
@@ -15,6 +15,7 @@ func newLoginCommand(app *App) *cobra.Command {
 	var email string
 	var password string
 	var mfa string
+	var acceptDisclaimer bool
 	command := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to an Obsidian account",
@@ -42,6 +43,29 @@ func newLoginCommand(app *App) *cobra.Command {
 			if existingToken != "" {
 				_ = app.client().SignOut(cmd.Context(), existingToken)
 				_ = app.configManager.ClearAuthToken()
+			}
+
+			// Show disclaimer and require acceptance
+			if !acceptDisclaimer {
+				_, _ = fmt.Fprint(app.stdout, `╔══════════════════════════════════════════════════════════════╗
+║                       ⚠️  DISCLAIMER  ⚠️                      ║
+║                                                              ║
+║  Obsidian Headless is a third-party, community-maintained    ║
+║  tool. It is NOT an official Obsidian product, and it is    ║
+║  NOT supported by Obsidian.                                  ║
+║                                                              ║
+║  If you encounter any issues, do NOT contact Obsidian        ║
+║  support. Instead, please open an issue on GitHub:           ║
+║  https://github.com/Belphemur/obsidian-headless/issues       ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+`)
+				_, _ = fmt.Fprint(app.stdout, "Do you understand and accept this disclaimer? (y/N): ")
+				var response string
+				_, _ = fmt.Fscanln(app.stdin, &response)
+				if !strings.HasPrefix(strings.ToLower(response), "y") {
+					return fmt.Errorf("Login cancelled. You must accept the disclaimer to proceed.")
+				}
 			}
 
 			// Get credentials from flags or prompt
@@ -100,6 +124,7 @@ func newLoginCommand(app *App) *cobra.Command {
 	command.Flags().StringVar(&email, "email", "", "account email")
 	command.Flags().StringVar(&password, "password", "", "account password")
 	command.Flags().StringVar(&mfa, "mfa", "", "MFA code")
+	command.Flags().BoolVar(&acceptDisclaimer, "accept-disclaimer", false, "accept the third-party disclaimer non-interactively")
 
 	return command
 }

--- a/src/internal/cli/auth.go
+++ b/src/internal/cli/auth.go
@@ -39,20 +39,14 @@ func newLoginCommand(app *App) *cobra.Command {
 				// Token may be invalid, proceed with login
 			}
 
-			// If already logged in, sign out old session
-			if existingToken != "" {
-				_ = app.client().SignOut(cmd.Context(), existingToken)
-				_ = app.configManager.ClearAuthToken()
-			}
-
 			// Show disclaimer and require acceptance
 			if !acceptDisclaimer {
 				_, _ = fmt.Fprint(app.stdout, `╔══════════════════════════════════════════════════════════════╗
-║                       ⚠️  DISCLAIMER  ⚠️                      ║
+║                       !! DISCLAIMER !!                       ║
 ║                                                              ║
-║  Obsidian Headless is a third-party, community-maintained    ║
-║  tool. It is NOT an official Obsidian product, and it is    ║
-║  NOT supported by Obsidian.                                  ║
+║  Obsidian Headless Go is a third-party, community-           ║
+║  maintained tool. It is NOT an official Obsidian product,    ║
+║  and it is NOT supported by Obsidian.                        ║
 ║                                                              ║
 ║  If you encounter any issues, do NOT contact Obsidian        ║
 ║  support. Instead, please open an issue on GitHub:           ║
@@ -64,8 +58,14 @@ func newLoginCommand(app *App) *cobra.Command {
 				var response string
 				_, _ = fmt.Fscanln(app.stdin, &response)
 				if !strings.HasPrefix(strings.ToLower(response), "y") {
-					return fmt.Errorf("Login cancelled. You must accept the disclaimer to proceed.")
+					return fmt.Errorf("login cancelled: you must accept the disclaimer to proceed")
 				}
+			}
+
+			// If already logged in, sign out old session
+			if existingToken != "" {
+				_ = app.client().SignOut(cmd.Context(), existingToken)
+				_ = app.configManager.ClearAuthToken()
 			}
 
 			// Get credentials from flags or prompt

--- a/website/src/README.md
+++ b/website/src/README.md
@@ -57,7 +57,7 @@ See the full **[Getting Started guide](./getting-started.md)** for detailed step
 
 ## What is Obsidian Headless Go?
 
-Obsidian Headless Go is the official CLI companion for [Obsidian Sync](https://obsidian.md/sync) and [Obsidian Publish](https://obsidian.md/publish). It brings the full power of Obsidian's sync and publish engines to the command line — no GUI required.
+Obsidian Headless Go is a community-maintained CLI companion for [Obsidian Sync](https://obsidian.md/sync) and [Obsidian Publish](https://obsidian.md/publish). It brings the full power of Obsidian's sync and publish engines to the command line — no GUI required.
 
 Perfect for:
 
@@ -65,3 +65,9 @@ Perfect for:
 - **CI/CD:** Publish documentation sites automatically on push
 - **Docker:** Run sync as a container with environment variables
 - **Automation:** Script sync and publish operations in your workflow
+
+::: danger ⚠️ Third-Party Disclaimer
+**Obsidian Headless Go is a third-party, community-maintained tool.** It is NOT an official Obsidian product, and it is NOT supported by Obsidian.
+
+If you encounter any issues, do **NOT** contact Obsidian support. Instead, please [open an issue on GitHub](https://github.com/Belphemur/obsidian-headless/issues).
+:::

--- a/website/src/getting-started.md
+++ b/website/src/getting-started.md
@@ -4,11 +4,17 @@ title: Getting Started
 
 # Getting Started
 
+::: danger ⚠️ Third-Party Disclaimer
+**Obsidian Headless Go is a third-party, community-maintained tool.** It is NOT an official Obsidian product, and it is NOT supported by Obsidian.
+
+If you encounter any issues, do **NOT** contact Obsidian support. Instead, please [open an issue on GitHub](https://github.com/Belphemur/obsidian-headless/issues).
+:::
+
 Choose your setup: run Obsidian Headless Go as a Docker container or install the CLI directly on your machine.
 
 ## Docker Quick Start
 
-The Docker image handles everything — just log in, configure, and start.
+The Docker image handles everything — just log in, configure, and start. This is a third-party tool; see the disclaimer above.
 
 ### Step 1 — Log in (one-time)
 
@@ -137,7 +143,7 @@ ob --version
 
 ### Step 2 — Log in to your Obsidian account
 
-The `ob login` command authenticates you with Obsidian Sync and Publish:
+The `ob login` command authenticates you with Obsidian Sync and Publish. When running login, you will be prompted to accept the third-party disclaimer first:
 
 ```bash
 ob login


### PR DESCRIPTION
## Summary

Adds a third-party disclaimer to the CLI login command and website to clarify that Obsidian Headless Go is **not** an official Obsidian product.

### Changes

#### CLI (`ob login`)
- Shows a disclaimer box before credentials prompt, requiring user acceptance (`y/N`)
- If declined, exits with: `Login cancelled. You must accept the disclaimer to proceed.`
- Added `--accept-disclaimer` flag for non-interactive / CI usage
- Disclaimer is **not shown** when just checking login status (`ob login` with no args when already authenticated)

#### Website
- Homepage: Changed "official CLI companion" → "community-maintained CLI companion"
- Homepage: Added `::: danger` disclaimer warning box
- Getting Started: Added `::: danger` disclaimer warning box at top
- Getting Started: Updated references to mention the disclaimer prompt

#### Tests
- Updated e2e login test to pass `--accept-disclaimer` flag

### Files Changed
- `src/internal/cli/auth.go` — disclaimer prompt + flag
- `src/cmd/ob-go/e2e_test.go` — test flag
- `website/src/README.md` — homepage disclaimer
- `website/src/getting-started.md` — getting-started disclaimer