### PR TITLE
feat(watch): detect file renames via inode tracking

### DIFF
--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -445,7 +445,10 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			return nil
 		case <-trigger:
 			scheduleSync()
-		case ev := <-watcher.Out:
+		case ev, ok := <-watcher.Out:
+			if !ok {
+				return nil
+			}
 			if ev.Type == watchpkg.EventRename {
 				renamesMu.Lock()
 				pendingRenames = append(pendingRenames, ev)

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
 
 	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
 	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
@@ -28,7 +29,7 @@ const (
 // file renames detected by the watcher. Without this, a rename from oldPath→newPath
 // would appear as a delete of oldPath + create of newPath in buildPlan.
 // The record's PreviousPath field is set to preserve the rename chain.
-func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent) {
+func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent, logger zerolog.Logger) {
 	for _, ev := range renames {
 		if ev.Type != watchpkg.EventRename {
 			continue
@@ -38,12 +39,20 @@ func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord
 			oldLocal.Path = ev.Path
 			previousLocal[ev.Path] = oldLocal
 			delete(previousLocal, ev.OldPath)
+			logger.Info().
+				Str("oldPath", ev.OldPath).
+				Str("newPath", ev.Path).
+				Msg("continuous: local rename applied")
 		}
 		if oldRemote, ok := previousRemote[ev.OldPath]; ok {
 			oldRemote.PreviousPath = ev.OldPath
 			oldRemote.Path = ev.Path
 			previousRemote[ev.Path] = oldRemote
 			delete(previousRemote, ev.OldPath)
+			logger.Info().
+				Str("oldPath", ev.OldPath).
+				Str("newPath", ev.Path).
+				Msg("continuous: remote rename applied")
 		}
 	}
 }
@@ -329,7 +338,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		pendingRenames = pendingRenames[:0]
 		renamesMu.Unlock()
 
-		applyRenameFixups(previousLocal, previousRemote, snapshot)
+		applyRenameFixups(previousLocal, previousRemote, snapshot, e.Logger)
 
 		dbLocal := previousLocal
 		dbRemote := previousRemote

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -24,6 +24,30 @@ const (
 	heartbeatTimeout       = 120 * time.Second
 )
 
+// applyRenameFixups mutates previousLocal and previousRemote in-place to reflect
+// file renames detected by the watcher. Without this, a rename from oldPath→newPath
+// would appear as a delete of oldPath + create of newPath in buildPlan.
+// The record's PreviousPath field is set to preserve the rename chain.
+func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent) {
+	for _, ev := range renames {
+		if ev.Type != watchpkg.EventRename {
+			continue
+		}
+		if oldLocal, ok := previousLocal[ev.OldPath]; ok {
+			oldLocal.PreviousPath = ev.OldPath
+			oldLocal.Path = ev.Path
+			previousLocal[ev.Path] = oldLocal
+			delete(previousLocal, ev.OldPath)
+		}
+		if oldRemote, ok := previousRemote[ev.OldPath]; ok {
+			oldRemote.PreviousPath = ev.OldPath
+			oldRemote.Path = ev.Path
+			previousRemote[ev.Path] = oldRemote
+			delete(previousRemote, ev.OldPath)
+		}
+	}
+}
+
 type continuousState struct {
 	mu            sync.Mutex
 	conn          *websocket.Conn
@@ -260,6 +284,11 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 
 	var debounceTimer *time.Timer
 	var debounceMu sync.Mutex
+
+	// Rename event collection for inode-based rename detection
+	var pendingRenames []watchpkg.ScanEvent
+	var renamesMu sync.Mutex
+
 	var doSync func()
 
 	scheduleSync := func() {
@@ -293,6 +322,14 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			e.Logger.Error().Err(err).Msg("continuous: failed to load state")
 			return
 		}
+
+		renamesMu.Lock()
+		snapshot := make([]watchpkg.ScanEvent, len(pendingRenames))
+		copy(snapshot, pendingRenames)
+		pendingRenames = pendingRenames[:0]
+		renamesMu.Unlock()
+
+		applyRenameFixups(previousLocal, previousRemote, snapshot)
 
 		dbLocal := previousLocal
 		dbRemote := previousRemote
@@ -399,7 +436,12 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			return nil
 		case <-trigger:
 			scheduleSync()
-		case <-watcher.Out:
+		case ev := <-watcher.Out:
+			if ev.Type == watchpkg.EventRename {
+				renamesMu.Lock()
+				pendingRenames = append(pendingRenames, ev)
+				renamesMu.Unlock()
+			}
 			scheduleSync()
 		case <-readPumpDone:
 			e.Logger.Info().Msg("continuous: readPump exited, reconnecting...")

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
 	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
 	watchpkg "github.com/Belphemur/obsidian-headless/src-go/internal/sync/watch"
+	"github.com/rs/zerolog"
 )
 
 func TestContinuousInitialSync(t *testing.T) {
@@ -529,7 +530,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames)
+		applyRenameFixups(local, remote, renames, zerolog.Nop())
 
 		// Old path should be gone
 		if _, ok := local[oldPath]; ok {
@@ -560,7 +561,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames)
+		applyRenameFixups(local, remote, renames, zerolog.Nop())
 
 		rec, ok := remote[newPath]
 		if !ok {
@@ -581,7 +582,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: newPath, OldPath: "nonexistent.md", Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames)
+		applyRenameFixups(local, remote, renames, zerolog.Nop())
 
 		// Should not panic, no records added
 		if len(local) != 0 || len(remote) != 0 {
@@ -599,7 +600,7 @@ func TestApplyRenameFixups(t *testing.T) {
 			{Path: oldPath, Type: watchpkg.EventRemove},
 			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames)
+		applyRenameFixups(local, remote, renames, zerolog.Nop())
 
 		// Only the rename should be applied, not the remove
 		rec, ok := local[newPath]

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
 	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
+	watchpkg "github.com/Belphemur/obsidian-headless/src-go/internal/sync/watch"
 )
 
 func TestContinuousInitialSync(t *testing.T) {
@@ -513,4 +514,100 @@ func TestContinuousHeartbeatAfterReconnect(t *testing.T) {
 	if err := <-errCh; err != nil && err != context.Canceled {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
+}
+
+func TestApplyRenameFixups(t *testing.T) {
+	oldPath := "old/file.md"
+	newPath := "new/file.md"
+
+	t.Run("local rename fixup", func(t *testing.T) {
+		local := map[string]model.FileRecord{
+			oldPath: {Path: oldPath, Hash: "abcdef", Size: 100, MTime: 1000},
+		}
+		remote := map[string]model.FileRecord{}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+		}
+		applyRenameFixups(local, remote, renames)
+
+		// Old path should be gone
+		if _, ok := local[oldPath]; ok {
+			t.Fatal("expected old path to be deleted from local")
+		}
+		// New path should have the record
+		rec, ok := local[newPath]
+		if !ok {
+			t.Fatal("expected new path to exist in local")
+		}
+		if rec.Hash != "abcdef" {
+			t.Fatalf("expected hash 'abcdef', got %s", rec.Hash)
+		}
+		if rec.Path != newPath {
+			t.Fatalf("expected Path %s, got %s", newPath, rec.Path)
+		}
+		if rec.PreviousPath != oldPath {
+			t.Fatalf("expected PreviousPath %s, got %s", oldPath, rec.PreviousPath)
+		}
+	})
+
+	t.Run("remote rename fixup", func(t *testing.T) {
+		local := map[string]model.FileRecord{}
+		remote := map[string]model.FileRecord{
+			oldPath: {Path: oldPath, Hash: "fedcba", Size: 200, MTime: 2000},
+		}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+		}
+		applyRenameFixups(local, remote, renames)
+
+		rec, ok := remote[newPath]
+		if !ok {
+			t.Fatal("expected new path to exist in remote")
+		}
+		if rec.Hash != "fedcba" {
+			t.Fatalf("expected hash 'fedcba', got %s", rec.Hash)
+		}
+		if rec.PreviousPath != oldPath {
+			t.Fatalf("expected PreviousPath %s, got %s", oldPath, rec.PreviousPath)
+		}
+	})
+
+	t.Run("no matching record", func(t *testing.T) {
+		local := map[string]model.FileRecord{}
+		remote := map[string]model.FileRecord{}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: newPath, OldPath: "nonexistent.md", Type: watchpkg.EventRename},
+		}
+		applyRenameFixups(local, remote, renames)
+
+		// Should not panic, no records added
+		if len(local) != 0 || len(remote) != 0 {
+			t.Fatal("expected no side effects for unmatched rename")
+		}
+	})
+
+	t.Run("non-rename event ignored", func(t *testing.T) {
+		local := map[string]model.FileRecord{
+			oldPath: {Path: oldPath, Hash: "abc", Size: 100, MTime: 1000},
+		}
+		remote := map[string]model.FileRecord{}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: oldPath, Type: watchpkg.EventRemove},
+			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+		}
+		applyRenameFixups(local, remote, renames)
+
+		// Only the rename should be applied, not the remove
+		rec, ok := local[newPath]
+		if !ok {
+			t.Fatal("expected rename to be applied")
+		}
+		if rec.PreviousPath != oldPath {
+			t.Fatalf("expected PreviousPath %s, got %s", oldPath, rec.PreviousPath)
+		}
+	})
 }

--- a/src/internal/sync/watch/aggregator.go
+++ b/src/internal/sync/watch/aggregator.go
@@ -42,6 +42,7 @@ func (a *Aggregator) Push(path string, eventType EventType) {
 		pending.timer.Stop()
 		pending.lastSeen = now
 		pending.eventType = eventType
+		pending.oldPath = ""
 		pending.token++
 		token := pending.token
 		delay := quiescenceDelay

--- a/src/internal/sync/watch/aggregator.go
+++ b/src/internal/sync/watch/aggregator.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const (
+var (
 	quiescenceDelay    = 2 * time.Second
 	maxSuppressionTime = 10 * time.Minute
 )
@@ -17,6 +17,7 @@ type pendingEvent struct {
 	lastSeen  time.Time
 	timer     *time.Timer
 	token     uint64
+	oldPath   string // only set for rename events
 }
 
 type Aggregator struct {
@@ -55,6 +56,32 @@ func (a *Aggregator) Push(path string, eventType EventType) {
 	a.pending[path] = pending
 }
 
+func (a *Aggregator) PushRename(path, oldPath string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return
+	}
+	now := time.Now()
+	if pending, ok := a.pending[path]; ok {
+		pending.timer.Stop()
+		pending.lastSeen = now
+		pending.eventType = EventRename
+		pending.oldPath = oldPath
+		pending.token++
+		token := pending.token
+		delay := quiescenceDelay
+		if now.Sub(pending.firstSeen) >= maxSuppressionTime {
+			delay = 0
+		}
+		pending.timer = time.AfterFunc(delay, func() { a.emit(path, pending, token) })
+		return
+	}
+	pending := &pendingEvent{eventType: EventRename, firstSeen: now, lastSeen: now, token: 1, oldPath: oldPath}
+	pending.timer = time.AfterFunc(quiescenceDelay, func() { a.emit(path, pending, pending.token) })
+	a.pending[path] = pending
+}
+
 func (a *Aggregator) Shutdown(ctx context.Context) bool {
 	a.mu.Lock()
 	if a.closed {
@@ -65,7 +92,7 @@ func (a *Aggregator) Shutdown(ctx context.Context) bool {
 	events := make([]ScanEvent, 0, len(a.pending))
 	for path, pending := range a.pending {
 		pending.timer.Stop()
-		events = append(events, ScanEvent{Path: path, Type: pending.eventType, DetectedAt: pending.lastSeen})
+		events = append(events, ScanEvent{Path: path, Type: pending.eventType, DetectedAt: pending.lastSeen, OldPath: pending.oldPath})
 	}
 	clear(a.pending)
 	a.mu.Unlock()
@@ -87,7 +114,7 @@ func (a *Aggregator) emit(path string, pending *pendingEvent, token uint64) {
 		return
 	}
 	delete(a.pending, path)
-	event := ScanEvent{Path: path, Type: pending.eventType, DetectedAt: pending.lastSeen}
+	event := ScanEvent{Path: path, Type: pending.eventType, DetectedAt: pending.lastSeen, OldPath: pending.oldPath}
 	a.mu.Unlock()
 	a.out <- event
 }

--- a/src/internal/sync/watch/aggregator_test.go
+++ b/src/internal/sync/watch/aggregator_test.go
@@ -34,7 +34,9 @@ func TestAggregator_PushRename_Overwrites(t *testing.T) {
 	agg := NewAggregator(out)
 
 	// First push a regular create
+	oldDelay := quiescenceDelay
 	quiescenceDelay = 500 * time.Millisecond // reduce delay for test
+	t.Cleanup(func() { quiescenceDelay = oldDelay })
 	agg.Push("/test", EventCreate)
 
 	// Then push a rename for the same path (should overwrite create)

--- a/src/internal/sync/watch/aggregator_test.go
+++ b/src/internal/sync/watch/aggregator_test.go
@@ -1,0 +1,89 @@
+package watch
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAggregator_PushRename(t *testing.T) {
+	out := make(chan ScanEvent, 10)
+	agg := NewAggregator(out)
+
+	agg.PushRename("/new/path", "/old/path")
+
+	// Wait for quiescence delay to expire
+	select {
+	case ev := <-out:
+		if ev.Type != EventRename {
+			t.Fatalf("expected EventRename, got %s", ev.Type)
+		}
+		if ev.Path != "/new/path" {
+			t.Fatalf("expected path /new/path, got %s", ev.Path)
+		}
+		if ev.OldPath != "/old/path" {
+			t.Fatalf("expected oldPath /old/path, got %s", ev.OldPath)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for rename event")
+	}
+}
+
+func TestAggregator_PushRename_Overwrites(t *testing.T) {
+	out := make(chan ScanEvent, 10)
+	agg := NewAggregator(out)
+
+	// First push a regular create
+	quiescenceDelay = 500 * time.Millisecond // reduce delay for test
+	agg.Push("/test", EventCreate)
+
+	// Then push a rename for the same path (should overwrite create)
+	agg.PushRename("/test", "/old")
+
+	select {
+	case ev := <-out:
+		if ev.Type != EventRename {
+			t.Fatalf("expected EventRename (rename should overwrite create), got %s", ev.Type)
+		}
+		if ev.Path != "/test" {
+			t.Fatalf("expected path /test, got %s", ev.Path)
+		}
+		if ev.OldPath != "/old" {
+			t.Fatalf("expected oldPath /old, got %s", ev.OldPath)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for rename event")
+	}
+}
+
+func TestAggregator_Shutdown_PreservesOldPath(t *testing.T) {
+	out := make(chan ScanEvent, 10)
+	agg := NewAggregator(out)
+
+	agg.PushRename("/new", "/old")
+
+	// Shutdown immediately (don't wait for quiescence)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		agg.Shutdown(ctx)
+		close(done)
+	}()
+
+	select {
+	case ev := <-out:
+		if ev.Type != EventRename {
+			t.Fatalf("expected EventRename from shutdown, got %s", ev.Type)
+		}
+		if ev.OldPath != "/old" {
+			t.Fatalf("expected oldPath /old, got %s", ev.OldPath)
+		}
+		if ev.Path != "/new" {
+			t.Fatalf("expected path /new, got %s", ev.Path)
+		}
+	case <-done:
+		t.Fatal("expected event from Shutdown")
+	}
+}

--- a/src/internal/sync/watch/event.go
+++ b/src/internal/sync/watch/event.go
@@ -33,4 +33,5 @@ type ScanEvent struct {
 	Path       string
 	Type       EventType
 	DetectedAt time.Time
+	OldPath    string // previous path; only valid when Type == EventRename
 }

--- a/src/internal/sync/watch/inode_unix.go
+++ b/src/internal/sync/watch/inode_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package watch
+
+import (
+	"os"
+	"syscall"
+)
+
+func getInode(info os.FileInfo) uint64 {
+	if info == nil {
+		return 0
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return stat.Ino
+}

--- a/src/internal/sync/watch/inode_windows.go
+++ b/src/internal/sync/watch/inode_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package watch
+
+import "os"
+
+func getInode(info os.FileInfo) uint64 {
+	return 0
+}

--- a/src/internal/sync/watch/scanner.go
+++ b/src/internal/sync/watch/scanner.go
@@ -3,7 +3,6 @@ package watch
 import (
 	"os"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -17,18 +16,6 @@ type FileState struct {
 type Scanner struct {
 	mu    sync.RWMutex
 	state map[string]FileState
-}
-
-func getInode(info os.FileInfo) uint64 {
-	if info == nil {
-		return 0
-	}
-	// Use syscall.Stat_t for Unix-like platforms; returns 0 on Windows.
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0
-	}
-	return stat.Ino
 }
 
 func NewScanner() *Scanner {

--- a/src/internal/sync/watch/scanner.go
+++ b/src/internal/sync/watch/scanner.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"os"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -10,11 +11,24 @@ type FileState struct {
 	ModTime time.Time
 	Size    int64
 	Mode    os.FileMode
+	Ino     uint64
 }
 
 type Scanner struct {
 	mu    sync.RWMutex
 	state map[string]FileState
+}
+
+func getInode(info os.FileInfo) uint64 {
+	if info == nil {
+		return 0
+	}
+	// Use syscall.Stat_t for Unix-like platforms; returns 0 on Windows.
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return stat.Ino
 }
 
 func NewScanner() *Scanner {
@@ -33,8 +47,8 @@ func (s *Scanner) HasChanged(path string) (bool, EventType) {
 	s.mu.RLock()
 	previous, known := s.state[path]
 	s.mu.RUnlock()
-	current := FileState{ModTime: info.ModTime(), Size: info.Size(), Mode: info.Mode()}
-	if !known || previous.ModTime != current.ModTime || previous.Size != current.Size || previous.Mode != current.Mode {
+	current := FileState{ModTime: info.ModTime(), Size: info.Size(), Mode: info.Mode(), Ino: getInode(info)}
+	if !known || previous.ModTime != current.ModTime || previous.Size != current.Size || previous.Mode != current.Mode || previous.Ino != current.Ino {
 		s.mu.Lock()
 		s.state[path] = current
 		s.mu.Unlock()
@@ -51,9 +65,23 @@ func (s *Scanner) Update(path string) {
 	if err != nil {
 		return
 	}
+	s.UpdateInfo(path, info)
+}
+
+func (s *Scanner) UpdateInfo(path string, info os.FileInfo) {
 	s.mu.Lock()
-	s.state[path] = FileState{ModTime: info.ModTime(), Size: info.Size(), Mode: info.Mode()}
+	s.state[path] = FileState{ModTime: info.ModTime(), Size: info.Size(), Mode: info.Mode(), Ino: getInode(info)}
 	s.mu.Unlock()
+}
+
+func (s *Scanner) GetInode(path string) (uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	fs, ok := s.state[path]
+	if !ok {
+		return 0, false
+	}
+	return fs.Ino, true
 }
 
 func (s *Scanner) Remove(path string) {

--- a/src/internal/sync/watch/scanner_test.go
+++ b/src/internal/sync/watch/scanner_test.go
@@ -1,0 +1,163 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestGetInode_Unix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inode not available on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ino := getInode(info)
+	if ino == 0 {
+		t.Fatal("expected non-zero inode on Unix")
+	}
+}
+
+func TestGetInode_Nil(t *testing.T) {
+	if ino := getInode(nil); ino != 0 {
+		t.Fatalf("expected 0 for nil FileInfo, got %d", ino)
+	}
+}
+
+func TestGetInode_Windows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("test only valid on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ino := getInode(info)
+	if ino != 0 {
+		t.Fatalf("expected 0 inode on Windows, got %d", ino)
+	}
+}
+
+func TestScanner_HasChanged_InodeDetection(t *testing.T) {
+	s := NewScanner()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+
+	// Create initial file
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	changed, eventType := s.HasChanged(path)
+	if !changed {
+		t.Fatal("expected change for new file")
+	}
+	if eventType != EventCreate {
+		t.Fatalf("expected EventCreate, got %s", eventType)
+	}
+
+	// Same file, no change
+	changed, _ = s.HasChanged(path)
+	if changed {
+		t.Fatal("expected no change for identical file")
+	}
+
+	// Modify the file
+	if err := os.WriteFile(path, []byte("world"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	changed, eventType = s.HasChanged(path)
+	if !changed {
+		t.Fatal("expected change for modified file")
+	}
+	if eventType != EventWrite {
+		t.Fatalf("expected EventWrite, got %s", eventType)
+	}
+}
+
+func TestScanner_GetInode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inode not available on Windows")
+	}
+	s := NewScanner()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	s.Update(path)
+
+	ino, ok := s.GetInode(path)
+	if !ok {
+		t.Fatal("expected inode to be found")
+	}
+	if ino == 0 {
+		t.Fatal("expected non-zero inode on Unix")
+	}
+
+	// Non-existent path
+	_, ok = s.GetInode("/nonexistent/path")
+	if ok {
+		t.Fatal("expected false for non-existent path")
+	}
+}
+
+func TestScanner_GetInode_Missing(t *testing.T) {
+	s := NewScanner()
+	_, ok := s.GetInode("/nonexistent")
+	if ok {
+		t.Fatal("expected false for missing path")
+	}
+}
+
+func TestScanner_UpdateInfo(t *testing.T) {
+	s := NewScanner()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.UpdateInfo(path, info)
+
+	changed, _ := s.HasChanged(path)
+	if changed {
+		t.Fatal("expected no change after UpdateInfo")
+	}
+}
+
+func TestScanner_Remove(t *testing.T) {
+	s := NewScanner()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	s.Update(path)
+
+	_, ok := s.GetInode(path)
+	if !ok {
+		t.Fatal("expected inode to exist before remove")
+	}
+
+	s.Remove(path)
+	_, ok = s.GetInode(path)
+	if ok {
+		t.Fatal("expected inode to not exist after remove")
+	}
+}

--- a/src/internal/sync/watch/watcher.go
+++ b/src/internal/sync/watch/watcher.go
@@ -16,7 +16,7 @@ import (
 
 const eventBufSize = 1024
 
-const renameDetectMS = 150 * time.Millisecond
+const renameDetectWindow = 150 * time.Millisecond
 
 type pendingRename struct {
 	ino   uint64
@@ -185,7 +185,21 @@ func (w *Watcher) handleFileCreate(path string, info os.FileInfo) {
 				w.agg.PushRename(path, pending.path)
 				return
 			}
-			w.renameMu.Unlock()
+			// Check for path match with different inode (delete+recreate)
+			if oldIno, exists := w.pendingRenamePaths[path]; exists && oldIno != ino {
+				if old, ok := w.pendingRenames[oldIno]; ok {
+					old.timer.Stop()
+					delete(w.pendingRenames, oldIno)
+					delete(w.pendingRenamePaths, path)
+					w.renameMu.Unlock()
+					w.logger.Info().Str("path", path).Msg("new file created at pending deletion path, cancelling deferred deletion")
+					// Fall through to normal create
+				} else {
+					w.renameMu.Unlock()
+				}
+			} else {
+				w.renameMu.Unlock()
+			}
 		}
 	}
 
@@ -205,7 +219,7 @@ func (w *Watcher) deferDeletion(path string, ino uint64) {
 		old.timer.Stop()
 		delete(w.pendingRenamePaths, old.path)
 	}
-	timer := time.AfterFunc(renameDetectMS, func() {
+	timer := time.AfterFunc(renameDetectWindow, func() {
 		// Timer expired without a matching create → real deletion
 		w.renameMu.Lock()
 		if _, ok := w.pendingRenames[ino]; ok {

--- a/src/internal/sync/watch/watcher.go
+++ b/src/internal/sync/watch/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,18 +16,30 @@ import (
 
 const eventBufSize = 1024
 
+const renameDetectMS = 150 * time.Millisecond
+
+type pendingRename struct {
+	ino   uint64
+	path  string
+	timer *time.Timer
+}
+
 type Watcher struct {
-	root           string
-	fw             *fsnotify.Watcher
-	agg            *Aggregator
-	scanner        *Scanner
-	excludes       []string
-	logger         zerolog.Logger
-	Out            chan ScanEvent
-	rescanInterval time.Duration
-	rescanning     atomic.Bool // guards against concurrent full-rescans
-	closing        atomic.Bool
-	wg             sync.WaitGroup
+	root                 string
+	fw                   *fsnotify.Watcher
+	agg                  *Aggregator
+	scanner              *Scanner
+	excludes             []string
+	logger               zerolog.Logger
+	Out                  chan ScanEvent
+	rescanInterval       time.Duration
+	rescanning           atomic.Bool // guards against concurrent full-rescans
+	closing              atomic.Bool
+	wg                   sync.WaitGroup
+	renameMu             sync.Mutex
+	inodeTrackingEnabled bool
+	pendingRenames       map[uint64]*pendingRename
+	pendingRenamePaths   map[string]uint64
 }
 
 func New(root string, excludes []string, logger zerolog.Logger, rescanInterval time.Duration) (*Watcher, error) {
@@ -45,6 +58,9 @@ func New(root string, excludes []string, logger zerolog.Logger, rescanInterval t
 		Out:            out,
 		rescanInterval: rescanInterval,
 	}
+	watcher.inodeTrackingEnabled = runtime.GOOS != "windows"
+	watcher.pendingRenames = make(map[uint64]*pendingRename)
+	watcher.pendingRenamePaths = make(map[string]uint64)
 	if err := watcher.addDirsRecursive(root); err != nil {
 		_ = fw.Close()
 		return nil, err
@@ -86,12 +102,24 @@ func (w *Watcher) Run(ctx context.Context) {
 func (w *Watcher) handle(event fsnotify.Event) {
 	w.logger.Debug().Str("path", event.Name).Str("ops", event.Op.String()).Msg("fs event")
 	if w.isExcluded(event.Name) {
-		w.logger.Debug().Str("path", event.Name).Msg("excluding event")
 		return
 	}
+
+	// Skip events for paths currently in a pending rename
+	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) {
+		w.renameMu.Lock()
+		_, pending := w.pendingRenamePaths[event.Name]
+		w.renameMu.Unlock()
+		if pending {
+			w.logger.Debug().Str("path", event.Name).Msg("skipping event for pending rename path")
+			return
+		}
+	}
+
 	if event.Has(fsnotify.Create) {
 		info, err := os.Lstat(event.Name)
 		if err == nil && info.IsDir() {
+			// Directories: emit create events for all files inside
 			w.logger.Info().Str("path", event.Name).Msg("directory created, adding watch")
 			w.startBackground(func() {
 				path := event.Name
@@ -99,32 +127,111 @@ func (w *Watcher) handle(event fsnotify.Event) {
 					w.logger.Error().Err(err).Str("path", path).Msg("failed to watch new directory")
 					return
 				}
-				// Emit create events for any files that already existed inside
-				// the newly-appeared directory (e.g. a directory rename/move).
 				_ = filepath.WalkDir(path, func(p string, d os.DirEntry, werr error) error {
 					if werr != nil || d.IsDir() || w.isExcluded(p) {
 						return nil
 					}
 					w.logger.Debug().Str("path", p).Msg("file in new directory")
-					w.agg.Push(p, EventCreate)
+					w.handleFileCreate(p, nil)
 					return nil
 				})
 			})
 			return
 		}
-		w.logger.Debug().Str("path", event.Name).Msg("file created")
+		w.handleFileCreate(event.Name, info)
+		return
 	}
+
 	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
 		w.logger.Info().Str("path", event.Name).Msg("file removed/renamed")
 		_ = w.fw.Remove(event.Name)
+
+		var ino uint64
+		var hasIno bool
+		if w.inodeTrackingEnabled {
+			ino, hasIno = w.scanner.GetInode(event.Name)
+		}
 		w.scanner.Remove(event.Name)
+
+		if w.inodeTrackingEnabled && hasIno && ino != 0 {
+			w.deferDeletion(event.Name, ino)
+			return
+		}
 		w.agg.Push(event.Name, EventRemove)
 		return
 	}
+
 	if changed, eventType := w.scanner.HasChanged(event.Name); changed {
 		w.logger.Debug().Str("path", event.Name).Str("type", eventType.String()).Msg("file changed")
 		w.agg.Push(event.Name, eventType)
 	}
+}
+
+func (w *Watcher) handleFileCreate(path string, info os.FileInfo) {
+	// Try to match this create against a pending deletion (rename detection)
+	if w.inodeTrackingEnabled && info != nil {
+		ino := getInode(info)
+		if ino != 0 {
+			w.renameMu.Lock()
+			if pending, ok := w.pendingRenames[ino]; ok {
+				// Found matching inode → it's a rename!
+				pending.timer.Stop()
+				delete(w.pendingRenames, ino)
+				delete(w.pendingRenamePaths, pending.path)
+				w.renameMu.Unlock()
+
+				w.scanner.UpdateInfo(path, info)
+				w.logger.Info().Str("oldPath", pending.path).Str("newPath", path).Msg("rename detected via inode match")
+				w.agg.PushRename(path, pending.path)
+				return
+			}
+			w.renameMu.Unlock()
+		}
+	}
+
+	// No rename match: regular file create
+	if info != nil {
+		w.scanner.UpdateInfo(path, info)
+	} else {
+		w.scanner.Update(path)
+	}
+	w.agg.Push(path, EventCreate)
+}
+
+func (w *Watcher) deferDeletion(path string, ino uint64) {
+	w.renameMu.Lock()
+	// Defensive: cancel any existing pending rename for this inode
+	if old, ok := w.pendingRenames[ino]; ok {
+		old.timer.Stop()
+		delete(w.pendingRenamePaths, old.path)
+	}
+	timer := time.AfterFunc(renameDetectMS, func() {
+		// Timer expired without a matching create → real deletion
+		w.renameMu.Lock()
+		if _, ok := w.pendingRenames[ino]; ok {
+			delete(w.pendingRenames, ino)
+			delete(w.pendingRenamePaths, path)
+			w.renameMu.Unlock()
+			w.agg.Push(path, EventRemove)
+			w.logger.Info().Str("path", path).Msg("rename window expired, emitting remove")
+		} else {
+			w.renameMu.Unlock()
+		}
+	})
+	w.pendingRenames[ino] = &pendingRename{ino: ino, path: path, timer: timer}
+	w.pendingRenamePaths[path] = ino
+	w.renameMu.Unlock()
+}
+
+func (w *Watcher) flushPendingRenames() {
+	w.renameMu.Lock()
+	defer w.renameMu.Unlock()
+	for _, pending := range w.pendingRenames {
+		pending.timer.Stop()
+		w.agg.Push(pending.path, EventRemove)
+	}
+	clear(w.pendingRenames)
+	clear(w.pendingRenamePaths)
 }
 
 // fullRescan walks the entire vault tree looking for metadata changes.
@@ -224,7 +331,12 @@ func (w *Watcher) shutdown(ctx context.Context) {
 	}
 	_ = w.fw.Close()
 	w.wg.Wait()
-	if !w.agg.Shutdown(ctx) {
+	w.flushPendingRenames()
+	// Use a fresh timeout context for aggregator shutdown so that pending
+	// events are flushed even when the parent context has been cancelled.
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !w.agg.Shutdown(flushCtx) {
 		w.logger.Warn().Msg("skipping final watcher flush during shutdown because cancellation fired first")
 	}
 	close(w.Out)

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -1,0 +1,203 @@
+package watch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func testLogger(t *testing.T) zerolog.Logger {
+	return zerolog.New(zerolog.NewConsoleWriter()).Level(zerolog.Disabled)
+}
+
+func TestWatcher_RenameDetection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inode tracking not available on Windows")
+	}
+
+	logger := testLogger(t)
+	root := t.TempDir()
+
+	w, err := New(root, nil, logger, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go w.Run(ctx)
+
+	// Create initial file
+	oldPath := filepath.Join(root, "old.md")
+	if err := os.WriteFile(oldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the Create event
+	var gotCreate bool
+	for !gotCreate {
+		select {
+		case ev := <-w.Out:
+			if ev.Type == EventCreate && ev.Path == oldPath {
+				gotCreate = true
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for initial Create event")
+		}
+	}
+
+	// Rename the file (atomic on same filesystem)
+	newPath := filepath.Join(root, "new.md")
+	if err := os.Rename(oldPath, newPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the rename event
+	select {
+	case ev := <-w.Out:
+		if ev.Type != EventRename {
+			t.Fatalf("expected EventRename, got %s", ev.Type)
+		}
+		if ev.Path != newPath {
+			t.Fatalf("expected new path %s, got %s", newPath, ev.Path)
+		}
+		if ev.OldPath != oldPath {
+			t.Fatalf("expected old path %s, got %s", oldPath, ev.OldPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for rename event")
+	}
+}
+
+func TestWatcher_RealDeletion_NoMatchingCreate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inode tracking not available on Windows")
+	}
+
+	logger := testLogger(t)
+	root := t.TempDir()
+
+	w, err := New(root, nil, logger, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go w.Run(ctx)
+
+	// Create file
+	path := filepath.Join(root, "temp.md")
+	if err := os.WriteFile(path, []byte("temp"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for Create
+	var gotCreate bool
+	for !gotCreate {
+		select {
+		case ev := <-w.Out:
+			if ev.Type == EventCreate && ev.Path == path {
+				gotCreate = true
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for Create event")
+		}
+	}
+
+	// Delete file
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for delete after window expiry (150ms + quiescence 2s)
+	select {
+	case ev := <-w.Out:
+		if ev.Type != EventRemove {
+			t.Fatalf("expected EventRemove, got %s", ev.Type)
+		}
+		if ev.Path != path {
+			t.Fatalf("expected path %s, got %s", path, ev.Path)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for Remove event")
+	}
+}
+
+func TestWatcher_Shutdown_FlushesPendingRenames(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inode tracking not available on Windows")
+	}
+
+	logger := testLogger(t)
+	root := t.TempDir()
+
+	w, err := New(root, nil, logger, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go w.Run(ctx)
+
+	// Create file so scanner knows about it
+	path := filepath.Join(root, "temp.md")
+	if err := os.WriteFile(path, []byte("temp"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for Create
+	var gotCreate bool
+	for !gotCreate {
+		select {
+		case ev := <-w.Out:
+			if ev.Type == EventCreate && ev.Path == path {
+				gotCreate = true
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for Create event")
+		}
+	}
+
+	// Remove file (should trigger deferDeletion)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Short wait to let the watcher process the fsnotify event
+	time.Sleep(200 * time.Millisecond)
+
+	// Immediately cancel (triggers shutdown -> flushPendingRenames)
+	cancel()
+
+	// Collect all remaining events
+	var foundRemove bool
+	timeout := time.After(3 * time.Second)
+loop:
+	for {
+		select {
+		case ev, ok := <-w.Out:
+			if !ok {
+				break loop
+			}
+			if ev.Type == EventRemove && ev.Path == path {
+				foundRemove = true
+				break loop
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+
+	if !foundRemove {
+		t.Fatal("expected EventRemove for pending deletion during shutdown")
+	}
+}


### PR DESCRIPTION
## Summary

Implements inode-based rename detection in the Go file watcher, matching the TypeScript version's behavior (`legacy/src/fs/adapter.ts`). When a file is renamed, the watcher now emits a single `EventRename` (with `OldPath`) instead of separate `EventRemove` + `EventCreate` events. This prevents the continuous sync engine from treating renames as delete+create (which would trigger unnecessary re-hashing and re-uploading).

## Changes

### Core Implementation (7 files)

| File | Change |
|---|---|
| `watch/event.go` | Added `OldPath string` to `ScanEvent` |
| `watch/scanner.go` | Added `Ino uint64` to `FileState`, `getInode()` helper (platform-gated), `GetInode()` method, `UpdateInfo()` |
| `watch/watcher.go` | Complete rewrite of `handle()`: 150ms deferred deletion, inode matching via `handleFileCreate()`, `deferDeletion()`, `flushPendingRenames()` |
| `watch/aggregator.go` | Added `PushRename()` method, `oldPath` field, `OldPath` propagation in `emit()`/`Shutdown()` |
| `sync/continuous.go` | Collects `EventRename` from watcher; `applyRenameFixups()` mutates previousLocal/previousRemote before buildPlan; sets `PreviousPath` on renamed records |

### Design Decisions

- **150ms detection window** — matches TypeScript's `RENAME_DETECT_MS`
- **Inode tracking disabled on Windows** — NTFS inode reuse makes them unreliable for rename detection
- **Directories** — emit separate remove+create events (no rename collapsing for dirs)
- **`PushRename`** as separate method on Aggregator (not variadic args) — follows Law of Atomic Predictability
- **`PreviousPath`** on `FileRecord` is now populated for local renames (was only from server pushes before)

### Bugfixes Found During Testing

- **`GetInode` ordering**: Must be called BEFORE `scanner.Remove()` — the previous code did inode lookup after deletion, making rename detection a no-op
- **`quiescenceDelay`**: Changed from `const` to `var` to allow tests to reduce the delay

## Testing (24 tests, all PASS)

- **14 watch tests**: rename detection, real deletion, shutdown flush, scanner inode tracking, aggregator PushRename/Shutdown
- **6 continuous tests**: all existing tests re-pass after refactor
- **4 fixup tests**: in-memory rename fixup, PreviousPath population, non-rename events ignored, unmatched renames

```
go test ./src/internal/sync/watch/... -count=1  # PASS (14 tests, ~5.4s)
go test ./src/internal/sync/ -run TestContinuous -count=1  # PASS (6 tests, ~66s)
```