### PR TITLE
fix(sync): detect remote renames, fix lock exclusivity, add sync guard

### DIFF
--- a/.agents/sync-docs/SKILL.md
+++ b/.agents/sync-docs/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-docs
+description: Enforce documentation updates when modifying sync logic. Triggers on changes to src/internal/sync/ or sync model types. Must update docs/architecture.md, docs/sync-protocol.md, website/src/architecture/sync-protocol.md, and website/src/usage/sync.md.
+license: MIT
+allowed-tools: Read
+---
+
+# Sync Documentation Maintenance
+
+When modifying any file under `src/internal/sync/` or `src/internal/model/types.go`,
+you MUST check and update the following documentation files:
+
+| Change Type | Files to Update |
+|------------|-----------------|
+| Protocol (push/pull/handshake) | `docs/sync-protocol.md`, `website/src/architecture/sync-protocol.md` |
+| Architecture (flow, modules, watcher) | `docs/architecture.md` |
+| User behavior (CLI, config) | `website/src/usage/sync.md` |
+| Data model (FileRecord fields) | `docs/sync-protocol.md`, `docs/architecture.md` |
+
+## Verification Checklist
+
+Before marking a sync task complete:
+- [ ] `docs/architecture.md` reflects new/changed sync behavior
+- [ ] `docs/sync-protocol.md` reflects new/changed protocol details
+- [ ] `website/src/architecture/sync-protocol.md` mirrors the protocol docs
+- [ ] `website/src/usage/sync.md` reflects user-facing behavior changes

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,9 +57,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X github.com/Belphemur/obsidian-headless/src-go/internal/buildinfo.Version={{.Version}}
-      - -X github.com/Belphemur/obsidian-headless/src-go/internal/buildinfo.Commit={{.Commit}}
-      - -X github.com/Belphemur/obsidian-headless/src-go/internal/buildinfo.Date={{ .CommitDate }}
+      - -X github.com/Belphemur/obsidian-headless/internal/buildinfo.Version={{.Version}}
+      - -X github.com/Belphemur/obsidian-headless/internal/buildinfo.Commit={{.Commit}}
+      - -X github.com/Belphemur/obsidian-headless/internal/buildinfo.Date={{ .CommitDate }}
     env:
       - CGO_ENABLED=0
 

--- a/.serena/memories/release/goreleaser-workflow.md
+++ b/.serena/memories/release/goreleaser-workflow.md
@@ -31,7 +31,7 @@ replace github.com/1password/onepassword-sdk-go => ./internal/1passwordstub
 The patch removes an intentional compile-error symbol in `client_builder_no_cgo.go`. See `docs/onepassword-cgo-workaround.md` for full details.
 
 ## Build Info Injection
-Version info is injected via ldflags into `src-go/internal/buildinfo`:
+Version info is injected via ldflags into `src/internal/buildinfo`:
 - `Version` — from `{{.Version}}`
 - `Commit` — from `{{.Commit}}`
 - `Date` — from `{{.CommitDate}}`

--- a/.serena/memories/src-go/logging/log-rotation.md
+++ b/.serena/memories/src-go/logging/log-rotation.md
@@ -10,7 +10,7 @@ The `sync.log` for each vault uses **lumberjack** for automatic rotation:
 
 ### Implementation
 
-Located in `src-go/internal/logging/logger.go`:
+Located in `src/internal/logging/logger.go`:
 
 - `NewFileLogger` creates a `zerolog.Logger` that writes to both console (`stderr`) and a `lumberjack.Logger`.
 - The returned cleanup function closes the lumberjack writer.

--- a/.serena/memories/src-go/sync/graceful-shutdown.md
+++ b/.serena/memories/src-go/sync/graceful-shutdown.md
@@ -28,8 +28,8 @@ Implemented clean shutdown on SIGINT/SIGTERM for the sync command to prevent dat
 - Websocket connections are closed to unblock I/O immediately
 
 ## Files Modified
-- `src-go/cmd/ob-go/main.go`
-- `src-go/internal/cli/sync.go`
-- `src-go/internal/sync/engine.go`
-- `src-go/internal/sync/continuous.go`
-- `src-go/internal/sync/engine_test.go`
+- `src/cmd/ob-go/main.go`
+- `src/internal/cli/sync.go`
+- `src/internal/sync/engine.go`
+- `src/internal/sync/continuous.go`
+- `src/internal/sync/engine_test.go`

--- a/.serena/memories/src-go/sync/illegal-filename-handling.md
+++ b/.serena/memories/src-go/sync/illegal-filename-handling.md
@@ -16,7 +16,7 @@
 - `sync.isValidPath` now delegates to `util.IsLegalPath`, so remote records with illegal chars are also filtered from sync plans and state.
 
 **Files changed:**
-- `src-go/internal/util/files.go` — `IsLegalPath`, `ScanVault`
-- `src-go/internal/sync/engine.go` — `scanLocal`
-- `src-go/internal/sync/plan.go` — `isValidPath`
-- `src-go/internal/util/files_test.go` — new tests
+- `src/internal/util/files.go` — `IsLegalPath`, `ScanVault`
+- `src/internal/sync/engine.go` — `scanLocal`
+- `src/internal/sync/plan.go` — `isValidPath`
+- `src/internal/util/files_test.go` — new tests

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync"],
             "env": {}
         },
@@ -15,7 +15,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-status"],
             "env": {}
         },
@@ -24,7 +24,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-config"],
             "env": {}
         },
@@ -33,7 +33,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-list-local"],
             "env": {}
         },
@@ -42,7 +42,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-list-remote"],
             "env": {}
         },
@@ -51,7 +51,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-create-remote"],
             "env": {}
         },
@@ -60,7 +60,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-setup"],
             "env": {}
         },
@@ -69,7 +69,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["sync-unlink"],
             "env": {}
         },
@@ -78,7 +78,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish"],
             "env": {}
         },
@@ -87,7 +87,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish-config"],
             "env": {}
         },
@@ -96,7 +96,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish-list-sites"],
             "env": {}
         },
@@ -105,7 +105,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish-create-site"],
             "env": {}
         },
@@ -114,7 +114,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish-setup"],
             "env": {}
         },
@@ -123,7 +123,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["publish-unlink"],
             "env": {}
         },
@@ -132,7 +132,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["login"],
             "env": {}
         },
@@ -141,7 +141,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["logout"],
             "env": {}
         },
@@ -150,7 +150,7 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src-go/cmd/ob-go",
+            "program": "${workspaceFolder}/src/cmd/ob-go",
             "args": ["completion"],
             "env": {}
         }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,33 @@ docs(readme): update installation instructions
 chore: update go.mod to use Go 1.26
 ```
 
+## Documentation
+
+When changing sync logic or protocol behavior, the following files MUST be kept in sync:
+
+- `docs/architecture.md` — architecture overview
+- `docs/sync-protocol.md` — protocol specification
+- `website/src/architecture/sync-protocol.md` — mirrored VuePress docs
+- `website/src/usage/sync.md` — user-facing usage docs
+
+Changes to protocol, architecture, or user behavior require updates in all four locations.
+
+## Commit Frequency
+
+Always commit along the way. Make multiple small, focused commits rather than one large monolithic commit. Each logical change gets its own commit. Commit messages follow Conventional Commits format with a clear scope.
+
+- Commit after each bug fix, new feature, documentation update, or refactor step
+- Keep commits small and reviewable — each commit should tell a clean story
+- Never leave uncommitted changes at the end of a session
+
 ## Project Structure
 
 - `legacy/` - TypeScript implementation (legacy)
 - `src/` - Go implementation (active development)
+
+### Source Code Location
+
+All active source code lives in the `src/` directory. The Go module root is at `src/go.mod` and the main entry point is `src/cmd/ob-go/main.go`. See `src/AGENTS.md` for Go-specific agent configuration.
 
 ## Memory Management
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download the `.zip` from [GitHub Releases](https://github.com/Belphemur/obsidian
 ### Go Install
 
 ```bash
-go install github.com/Belphemur/obsidian-headless/src-go/cmd/ob-go@latest
+go install github.com/Belphemur/obsidian-headless/cmd/ob-go@latest
 ```
 
 ### Build from Source

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Publish services.
 
 ```bash
 # Build and run the Go CLI
-cd src-go
+cd src
 go build -o ob ./cmd/ob-go
 ./ob --help
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,34 @@ single `"renamed"` event (with both old and new paths) instead of separate
 `"file-removed"` + `"file-created"` events. This lets the sync engine move the
 metadata record without re-hashing or re-uploading the unchanged content.
 
+### Remote rename detection (UID-based)
+
+When a file is renamed on another device, the Obsidian Sync server does not
+have a native "rename" protocol message. Instead it sends **two separate push
+notifications** that share the same UID:
+
+1. A push for `newPath` with the file content (`deleted: false`)
+2. A push for `oldPath` with `deleted: true`
+
+The client detects remote renames by correlating these two pushes via UID
+matching in `applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`):
+
+- If the local file at `oldPath` is **unmodified** (hash matches previous
+  state), it is renamed in-place on disk via `os.Rename` to `newPath`. The
+  sync state metadata moves with it — `PreviousPath` is set to preserve the
+  rename chain. No re-download is needed.
+- If the local file at `oldPath` was **modified** locally, it is preserved
+  at its original path and the conflict is logged. The remote version at
+  `newPath` is downloaded normally, and `buildPlan` handles the two files
+  independently.
+
+After renaming, the watcher is notified of the affected paths via
+`AddIgnorePaths()` so that the resulting filesystem events (from `os.Rename`)
+are suppressed and not misinterpreted as user-initiated renames.
+
+This detection runs in both `RunOnce` and continuous sync modes, before
+`buildPlan` is called.
+
 ### Watch disabled for read-only modes
 
 In `pull-only` and `mirror-remote` sync modes, local file changes are never

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,13 +121,16 @@ The client detects remote renames by correlating these two pushes via UID
 matching in `applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`):
 
 - If the local file at `oldPath` is **unmodified** (hash matches previous
-  state), it is renamed in-place on disk via `os.Rename` to `newPath`. The
-  sync state metadata moves with it — `PreviousPath` is set to preserve the
-  rename chain. No re-download is needed.
-- If the local file at `oldPath` was **modified** locally, it is preserved
-  at its original path and the conflict is logged. The remote version at
-  `newPath` is downloaded normally, and `buildPlan` handles the two files
-  independently.
+  state), parent directories are created and the file is renamed in-place on
+  disk via `os.Rename` to `newPath`. The sync state metadata moves with it —
+  `PreviousPath` is set to preserve the rename chain. No re-download is needed.
+- If the local file at `oldPath` was **modified** locally, or if there is no
+  previous state for `oldPath` in either `previousLocal` or `previousRemote`,
+  it is preserved at its original path and the conflict is logged. The remote
+  version at `newPath` is downloaded normally, and `buildPlan` handles the two
+  files independently.
+- Rename or directory-creation failures are recorded as conflicts rather than
+  returned as errors.
 
 After renaming, the watcher is notified of the affected paths via
 `AddIgnorePaths()` so that the resulting filesystem events (from `os.Rename`)

--- a/docs/go-port-progress.md
+++ b/docs/go-port-progress.md
@@ -1,7 +1,7 @@
 # Go Port Progress
 
 - [x] Review the existing TypeScript architecture, CLI docs, REST API docs, sync protocol docs, and mock-server docs
-- [x] Scaffold a dedicated `src-go/` Go module with package boundaries aligned to the TypeScript modules
+- [x] Scaffold a dedicated `src/` Go module with package boundaries aligned to the TypeScript modules
 - [x] Split the new Go CLI into focused packages and command files instead of a single root implementation
 - [x] Finish the Go REST client, config management, SQLite state store, and zerolog-based logging
 - [x] Finish the sync engine, including the Syncthing-style watcher, continuous mode, and mock-server compatibility
@@ -12,7 +12,7 @@
 
 ## Current status
 
-- The Go module scaffold exists under `src-go/`.
+- The Go module scaffold exists under `src/`.
 - Package structure now mirrors the TypeScript app at a high level: CLI, API, config, storage, sync, publish, utils, and logging.
 - The module now targets Go `1.26.0` and uses Cobra/Viper, `modernc.org/sqlite`, `zerolog`, `fsnotify`, `gorilla/websocket`, `doublestar`, and `yaml.v3`.
 - The Go CLI now has working login/logout, sync configuration and execution, publish configuration and execution, a SQLite-backed sync state store, and a Syncthing-style watcher pipeline for continuous sync.

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -198,6 +198,21 @@ client must detect and ignore these self-echoes to avoid infinite sync loops.
 A common approach is to compare the `device` and `mtime` fields with the most
 recently pushed file.
 
+### Rename Semantics
+
+The server does **not** communicate renames natively. When a file is renamed
+on the remote, the server sends two independent push notifications:
+
+1. A push for the **new path** with the file content (`deleted: false`)
+2. A push for the **old path** with `deleted: true`
+
+Both pushes share the **same `uid`** value, corresponding to the file's
+identity on the server. The client detects the rename by correlating
+deleted and active entries in the push map that share the same UID.
+
+This client-side UID correlation is implemented in
+`applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`).
+
 ### Ready Notification (Server → Client)
 
 Sent after all pending pushes have been delivered:

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -145,7 +145,7 @@ Sync uses WebSocket at the vault host for real-time file transfer.
 ## Running Locally
 
 ```bash
-cd src-go
+cd src
 GOTOOLCHAIN=go1.26.0 go run ./cmd/ob-go --help
 ```
 
@@ -198,7 +198,7 @@ func TestMain(m *testing.M) {
 
 This is already in place for:
 - `src/internal/config` package tests
-- `src-go` integration tests
+- `src` integration tests
 
 ## Testing
 
@@ -240,7 +240,7 @@ CI also runs `golangci-lint run` to enforce style, bug, and complexity checks au
 Run the following commands before committing:
 
 ```bash
-cd src-go
+cd src
 go fmt ./...
 go vet ./...
 go fix ./...

--- a/src/cmd/gendocs/main.go
+++ b/src/cmd/gendocs/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/cli"
+	"github.com/Belphemur/obsidian-headless/internal/cli"
 	"github.com/spf13/cobra/doc"
 )
 

--- a/src/cmd/ob-go/e2e_test.go
+++ b/src/cmd/ob-go/e2e_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/cli"
+	"github.com/Belphemur/obsidian-headless/internal/cli"
 )
 
 const apiBase = "http://127.0.0.1:3000"

--- a/src/cmd/ob-go/main.go
+++ b/src/cmd/ob-go/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/cli"
+	"github.com/Belphemur/obsidian-headless/internal/cli"
 )
 
 func main() {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/Belphemur/obsidian-headless/src-go
+module github.com/Belphemur/obsidian-headless
 
 go 1.26
 

--- a/src/internal/api/auth.go
+++ b/src/internal/api/auth.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func (c *Client) signIn(ctx context.Context, email, password, mfa string) (*model.SignInResponse, error) {

--- a/src/internal/api/client.go
+++ b/src/internal/api/client.go
@@ -9,9 +9,9 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/buildinfo"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/buildinfo"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 var userAgent = "obsidian-headless-go/" + buildinfo.Version

--- a/src/internal/api/helpers.go
+++ b/src/internal/api/helpers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
 )
 
 func (c *Client) postJSON(ctx context.Context, endpoint string, body any, target any, opts ...*RequestOptions) error {

--- a/src/internal/api/publish.go
+++ b/src/internal/api/publish.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func (c *Client) listPublishSites(ctx context.Context, token string) ([]model.PublishSite, error) {

--- a/src/internal/api/publish_test.go
+++ b/src/internal/api/publish_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func TestListPublishSites(t *testing.T) {

--- a/src/internal/api/vault.go
+++ b/src/internal/api/vault.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func (c *Client) regions(ctx context.Context, token string) ([]model.Region, error) {

--- a/src/internal/api/vault_test.go
+++ b/src/internal/api/vault_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func TestRegions(t *testing.T) {

--- a/src/internal/circuitbreaker/config_test.go
+++ b/src/internal/circuitbreaker/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
 	"github.com/rs/zerolog"
 	"github.com/sony/gobreaker/v2"
 	"github.com/stretchr/testify/assert"

--- a/src/internal/cli/app.go
+++ b/src/internal/cli/app.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/api"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/logging"
+	"github.com/Belphemur/obsidian-headless/internal/api"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/logging"
 )
 
 type App struct {

--- a/src/internal/cli/auth.go
+++ b/src/internal/cli/auth.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	apipkg "github.com/Belphemur/obsidian-headless/src-go/internal/api"
+	apipkg "github.com/Belphemur/obsidian-headless/internal/api"
 )
 
 func newLoginCommand(app *App) *cobra.Command {

--- a/src/internal/cli/publish.go
+++ b/src/internal/cli/publish.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	publishpkg "github.com/Belphemur/obsidian-headless/src-go/internal/publish"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	publishpkg "github.com/Belphemur/obsidian-headless/internal/publish"
 )
 
 func addPublishCommands(root *cobra.Command, app *App) {

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/buildinfo"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/buildinfo"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
 )
 
 type rootCommand struct {

--- a/src/internal/cli/sync.go
+++ b/src/internal/cli/sync.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/logging"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	syncpkg "github.com/Belphemur/obsidian-headless/src-go/internal/sync"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/util"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/logging"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	syncpkg "github.com/Belphemur/obsidian-headless/internal/sync"
+	"github.com/Belphemur/obsidian-headless/internal/util"
 )
 
 func addSyncCommands(root *cobra.Command, app *App) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 	"github.com/rs/zerolog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"

--- a/src/internal/config/secrets.go
+++ b/src/internal/config/secrets.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
 	"github.com/byteness/keyring"
 	"github.com/rs/zerolog"
 )

--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewConsoleLogger(output io.Writer) zerolog.Logger {
-	writer := zerolog.ConsoleWriter{Out: output}
+	writer := zerolog.ConsoleWriter{Out: output, TimeFormat: "15:04:05.000"}
 	return zerolog.New(writer).With().Timestamp().Logger()
 }
 
@@ -21,7 +21,7 @@ func NewFileLogger(stdout io.Writer, path string) (zerolog.Logger, func(), error
 		LocalTime:  true,
 		Compress:   true,
 	}
-	console := zerolog.ConsoleWriter{Out: stdout}
+	console := zerolog.ConsoleWriter{Out: stdout, TimeFormat: "15:04:05.000"}
 	logger := zerolog.New(io.MultiWriter(console, file)).With().Timestamp().Logger()
 	cleanup := func() {
 		_ = file.Close()

--- a/src/internal/model/types.go
+++ b/src/internal/model/types.go
@@ -101,6 +101,12 @@ func (r FileRecord) Equal(other FileRecord) bool {
 		r.User == other.User
 }
 
+// RenamePair represents an old→new path pair for a rename operation.
+type RenamePair struct {
+	OldPath string
+	NewPath string
+}
+
 type PublishCacheEntry struct {
 	Hash    string `json:"hash"`
 	MTime   int64  `json:"mtime"`

--- a/src/internal/publish/engine.go
+++ b/src/internal/publish/engine.go
@@ -12,10 +12,10 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/api"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/util"
+	"github.com/Belphemur/obsidian-headless/internal/api"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/util"
 )
 
 type Engine struct {

--- a/src/internal/storage/state.go
+++ b/src/internal/storage/state.go
@@ -14,7 +14,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 //go:embed migrations/sqlite/*.sql

--- a/src/internal/storage/state_test.go
+++ b/src/internal/storage/state_test.go
@@ -8,7 +8,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func TestMigrationFromV1WithExistingData(t *testing.T) {

--- a/src/internal/sync/connection.go
+++ b/src/internal/sync/connection.go
@@ -11,11 +11,11 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/encryption"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/encryption"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
 )
 
 func (e *Engine) ensureConnected(ctx context.Context) error {

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -64,6 +64,7 @@ func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord
 type continuousState struct {
 	mu             sync.Mutex
 	syncInProgress atomic.Bool
+	syncPending    atomic.Bool
 	conn           *websocket.Conn
 	remote         map[string]model.FileRecord
 	version        int64
@@ -330,6 +331,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 	doSync = func() {
 		if cs.syncInProgress.Swap(true) {
 			e.Logger.Debug().Msg("continuous: sync already in progress, skipping")
+			cs.syncPending.Store(true)
 			return
 		}
 		defer cs.syncInProgress.Store(false)
@@ -480,6 +482,12 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		e.Logger.Info().Msg("continuous: sync complete")
+
+		// If another sync was requested while this one was running, re-trigger
+		if cs.syncPending.Swap(false) {
+			e.Logger.Debug().Msg("continuous: re-triggering sync for pending changes")
+			scheduleSync()
+		}
 	}
 
 	// Always run a full sync on startup to catch local changes made

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -6,17 +6,18 @@ import (
 	"fmt"
 	"maps"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
-	watchpkg "github.com/Belphemur/obsidian-headless/src-go/internal/sync/watch"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
+	watchpkg "github.com/Belphemur/obsidian-headless/internal/sync/watch"
 )
 
 const (
@@ -61,12 +62,13 @@ func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord
 }
 
 type continuousState struct {
-	mu            sync.Mutex
-	conn          *websocket.Conn
-	remote        map[string]model.FileRecord
-	version       int64
-	stopClose     func() bool
-	lastMessageTs time.Time
+	mu             sync.Mutex
+	syncInProgress atomic.Bool
+	conn           *websocket.Conn
+	remote         map[string]model.FileRecord
+	version        int64
+	stopClose      func() bool
+	lastMessageTs  time.Time
 }
 
 func (e *Engine) RunContinuous(ctx context.Context) error {
@@ -326,6 +328,12 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 	}
 
 	doSync = func() {
+		if cs.syncInProgress.Swap(true) {
+			e.Logger.Debug().Msg("continuous: sync already in progress, skipping")
+			return
+		}
+		defer cs.syncInProgress.Store(false)
+
 		lock, err := e.acquireLock()
 		if err != nil {
 			e.Logger.Error().Err(err).Msg("continuous: failed to acquire lock")
@@ -353,6 +361,9 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		renamesMu.Unlock()
 
 		applyRenameFixups(previousLocal, previousRemote, snapshot, e.Logger)
+
+		// Flush stale ignorations from the previous sync cycle
+		watcher.FlushIgnored()
 
 		dbLocal := previousLocal
 		dbRemote := previousRemote
@@ -382,6 +393,22 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 		version := cs.version
 		cs.mu.Unlock()
+
+		// Detect and apply remote renames before building the plan
+		remoteRenameResult, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+		if err != nil {
+			e.Logger.Error().Err(err).Msg("continuous: remote rename fixup failed")
+			return
+		}
+		if len(remoteRenameResult.Conflicts) > 0 {
+			for _, conflictPath := range remoteRenameResult.Conflicts {
+				e.Logger.Warn().Str("path", conflictPath).Msg("continuous: local file modified, preserving during remote rename")
+			}
+		}
+		if len(remoteRenameResult.Enacted) > 0 {
+			// Suppress watcher events for paths affected by remote rename
+			watcher.AddIgnorePaths(remoteRenameResult.Enacted)
+		}
 
 		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 		e.Logger.Info().Int("planned_actions", len(plan)).Msg("continuous: sync plan created")

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -397,16 +397,8 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		cs.mu.Unlock()
 
 		// Detect and apply remote renames before building the plan
-		remoteRenameResult, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
-		if err != nil {
-			e.Logger.Error().Err(err).Msg("continuous: remote rename fixup failed")
-			return
-		}
-		if len(remoteRenameResult.Conflicts) > 0 {
-			for _, conflictPath := range remoteRenameResult.Conflicts {
-				e.Logger.Warn().Str("path", conflictPath).Msg("continuous: local file modified, preserving during remote rename")
-			}
-		}
+		remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+		e.logRemoteRenameConflicts(remoteRenameResult, "continuous")
 		if len(remoteRenameResult.Enacted) > 0 {
 			// Suppress watcher events for paths affected by remote rename
 			watcher.AddIgnorePaths(remoteRenameResult.Enacted)

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -335,6 +335,14 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			return
 		}
 		defer cs.syncInProgress.Store(false)
+		// If a sync request arrived while this one was running, re-trigger after completion.
+		// Placed in a defer so it runs on ALL exit paths (plan-empty, errors, success).
+		defer func() {
+			if cs.syncPending.Swap(false) {
+				e.Logger.Debug().Msg("continuous: re-triggering sync for pending changes")
+				scheduleSync()
+			}
+		}()
 
 		lock, err := e.acquireLock()
 		if err != nil {
@@ -367,8 +375,14 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		// Flush stale ignorations from the previous sync cycle
 		watcher.FlushIgnored()
 
-		dbLocal := previousLocal
-		dbRemote := previousRemote
+		// Clone previous state as the save-state baseline before any mutations.
+		// applyRemoteRenameFixups below mutates previousRemote in-place, so
+		// dbLocal/dbRemote must be independent copies — otherwise the baseline
+		// used by saveState to compute deletions would be corrupted.
+		dbLocal := make(map[string]model.FileRecord)
+		maps.Copy(dbLocal, previousLocal)
+		dbRemote := make(map[string]model.FileRecord)
+		maps.Copy(dbRemote, previousRemote)
 
 		initial, _ := store.Initial()
 		if initial {
@@ -474,12 +488,6 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		e.Logger.Info().Msg("continuous: sync complete")
-
-		// If another sync was requested while this one was running, re-trigger
-		if cs.syncPending.Swap(false) {
-			e.Logger.Debug().Msg("continuous: re-triggering sync for pending changes")
-			scheduleSync()
-		}
 	}
 
 	// Always run a full sync on startup to catch local changes made

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -410,13 +410,14 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		version := cs.version
 		cs.mu.Unlock()
 
-		// Detect and apply remote renames before building the plan
-		remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+		// Detect and apply remote renames before building the plan.
+		// Pass a callback to register watcher ignore paths before os.Rename
+		// so fsnotify events for our own rename are suppressed.
+		remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger,
+			func(pair model.RenamePair) {
+				watcher.AddIgnorePaths([]model.RenamePair{pair})
+			})
 		e.logRemoteRenameConflicts(remoteRenameResult, "continuous")
-		if len(remoteRenameResult.Enacted) > 0 {
-			// Suppress watcher events for paths affected by remote rename
-			watcher.AddIgnorePaths(remoteRenameResult.Enacted)
-		}
 
 		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 		e.Logger.Info().Int("planned_actions", len(plan)).Msg("continuous: sync plan created")

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -79,7 +79,8 @@ func TestContinuousInitialSync(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -135,7 +136,8 @@ func TestContinuousWatcherSync(t *testing.T) {
 	})
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -199,7 +201,8 @@ func TestContinuousPushSync(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -259,7 +262,8 @@ func TestContinuousReconnection(t *testing.T) {
 	})
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -321,7 +325,8 @@ func TestRunContinuousPeriodicScanZero(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	cancel()
 
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -361,7 +366,8 @@ func TestRunContinuousPeriodicScanEmptyDefault(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	cancel()
 
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -443,7 +449,8 @@ func TestContinuousInitialSyncWithStaleState(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }
@@ -502,7 +509,8 @@ func TestContinuousHeartbeatAfterReconnect(t *testing.T) {
 	})
 
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && err != context.Canceled &&
+		!strings.Contains(err.Error(), "operation was canceled") {
 		t.Fatalf("RunContinuous error: %v", err)
 	}
 }

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
-	watchpkg "github.com/Belphemur/obsidian-headless/src-go/internal/sync/watch"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
+	watchpkg "github.com/Belphemur/obsidian-headless/internal/sync/watch"
 	"github.com/rs/zerolog"
 )
 

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -118,8 +118,14 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 		return err
 	}
 
-	dbLocal := previousLocal
-	dbRemote := previousRemote
+	// Clone previous state as the save-state baseline before any mutations.
+	// applyRemoteRenameFixups mutates previousRemote in-place, so dbLocal/dbRemote
+	// must be independent copies — otherwise the baseline used by saveState to
+	// compute deletions would be corrupted.
+	dbLocal := make(map[string]model.FileRecord)
+	maps.Copy(dbLocal, previousLocal)
+	dbRemote := make(map[string]model.FileRecord)
+	maps.Copy(dbRemote, previousRemote)
 
 	initial, _ := store.Initial()
 	if initial {
@@ -204,13 +210,14 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 }
 
 // logRemoteRenameConflicts logs any paths that were preserved as conflicts
-// during remote rename detection (locally modified files, destination collisions, etc.).
+// during remote rename detection (locally modified files, destination collisions,
+// missing previous state, filesystem errors, etc.).
 func (e *Engine) logRemoteRenameConflicts(result *RemoteRenameResult, mode string) {
 	for _, path := range result.Conflicts {
 		e.Logger.Warn().
 			Str("path", path).
 			Str("mode", mode).
-			Msg("local file modified during remote rename, preserving")
+			Msg("remote rename conflict, preserving original path(s)")
 	}
 }
 

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -153,8 +153,9 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	version := e.version
 	e.mu.Unlock()
 
-	// Detect and apply remote renames before building the plan
-	remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+	// Detect and apply remote renames before building the plan.
+	// No watcher in RunOnce mode, so no pre-rename callback needed.
+	remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger, nil)
 	e.logRemoteRenameConflicts(remoteRenameResult, "once")
 
 	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -13,12 +13,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sony/gobreaker/v2"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/circuitbreaker"
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/encryption"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/util"
+	"github.com/Belphemur/obsidian-headless/internal/circuitbreaker"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
+	"github.com/Belphemur/obsidian-headless/internal/encryption"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
+	"github.com/Belphemur/obsidian-headless/internal/util"
 )
 
 const (
@@ -146,6 +146,17 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	}
 	version := e.version
 	e.mu.Unlock()
+
+	// Detect and apply remote renames before building the plan
+	remoteRenameResult, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+	if err != nil {
+		return fmt.Errorf("remote rename fixup failed: %w", err)
+	}
+	if len(remoteRenameResult.Conflicts) > 0 {
+		for _, conflictPath := range remoteRenameResult.Conflicts {
+			e.Logger.Warn().Str("path", conflictPath).Msg("RunOnce: local file modified, preserving during remote rename")
+		}
+	}
 
 	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 	e.Logger.Info().

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -148,15 +148,8 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	e.mu.Unlock()
 
 	// Detect and apply remote renames before building the plan
-	remoteRenameResult, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
-	if err != nil {
-		return fmt.Errorf("remote rename fixup failed: %w", err)
-	}
-	if len(remoteRenameResult.Conflicts) > 0 {
-		for _, conflictPath := range remoteRenameResult.Conflicts {
-			e.Logger.Warn().Str("path", conflictPath).Msg("RunOnce: local file modified, preserving during remote rename")
-		}
-	}
+	remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger)
+	e.logRemoteRenameConflicts(remoteRenameResult, "once")
 
 	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
 	e.Logger.Info().
@@ -208,6 +201,17 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 
 	e.Logger.Info().Str("vault", e.Config.VaultID).Msg("sync complete")
 	return nil
+}
+
+// logRemoteRenameConflicts logs any paths that were preserved as conflicts
+// during remote rename detection (locally modified files, destination collisions, etc.).
+func (e *Engine) logRemoteRenameConflicts(result *RemoteRenameResult, mode string) {
+	for _, path := range result.Conflicts {
+		e.Logger.Warn().
+			Str("path", path).
+			Str("mode", mode).
+			Msg("local file modified during remote rename, preserving")
+	}
 }
 
 func (e *Engine) Close() error {

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/storage"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/storage"
 )
 
 func testLogger() zerolog.Logger {

--- a/src/internal/sync/lock.go
+++ b/src/internal/sync/lock.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	configpkg "github.com/Belphemur/obsidian-headless/src-go/internal/config"
+	configpkg "github.com/Belphemur/obsidian-headless/internal/config"
 )
 
 func (e *Engine) acquireLock() (func(), error) {
@@ -14,31 +14,36 @@ func (e *Engine) acquireLock() (func(), error) {
 	if err := os.MkdirAll(lockDir, 0o755); err != nil {
 		return nil, err
 	}
-	lockName := e.Config.VaultID + ".lock"
-	lockFile := filepath.Join(lockDir, lockName)
-	f, err := os.Create(lockFile)
+	lockFile := filepath.Join(lockDir, e.Config.VaultID+".lock")
+
+	f, err := openExclusive(lockFile)
 	if err != nil {
-		if os.IsExist(err) {
-			info, statErr := os.Stat(lockFile)
-			if statErr == nil && time.Since(info.ModTime()) > staleLockAge {
-				if remErr := os.Remove(lockFile); remErr != nil {
-					return nil, fmt.Errorf("stale lock file but cannot remove: %w", remErr)
-				}
-				f, err = os.Create(lockFile)
-				if err != nil {
-					return nil, fmt.Errorf("lock file removed but cannot recreate: %w", err)
-				}
-			} else {
-				return nil, fmt.Errorf("sync in progress: %s", lockFile)
-			}
-		} else {
+		if !os.IsExist(err) {
 			return nil, fmt.Errorf("cannot create lock file: %w", err)
 		}
+
+		info, statErr := os.Stat(lockFile)
+		if statErr != nil || time.Since(info.ModTime()) <= staleLockAge {
+			return nil, fmt.Errorf("sync in progress: %s", lockFile)
+		}
+
+		if remErr := os.Remove(lockFile); remErr != nil {
+			return nil, fmt.Errorf("stale lock file but cannot remove: %w", remErr)
+		}
+
+		f, err = openExclusive(lockFile)
+		if err != nil {
+			return nil, fmt.Errorf("lock file removed but cannot recreate: %w", err)
+		}
 	}
+	defer f.Close()
+
 	host, _ := os.Hostname()
-	_, _ = fmt.Fprintf(f, "%d %s %s\n", os.Getpid(), host, time.Now().Format(time.RFC3339))
-	f.Close()
-	return func() {
-		_ = os.Remove(lockFile)
-	}, nil
+	fmt.Fprintf(f, "%d %s %s\n", os.Getpid(), host, time.Now().Format(time.RFC3339))
+
+	return func() { _ = os.Remove(lockFile) }, nil
+}
+
+func openExclusive(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 }

--- a/src/internal/sync/lock_test.go
+++ b/src/internal/sync/lock_test.go
@@ -1,0 +1,153 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Belphemur/obsidian-headless/internal/model"
+)
+
+func newTestEngine(t *testing.T, tmp string) *Engine {
+	t.Helper()
+	return &Engine{
+		Config: model.SyncConfig{
+			VaultID:   "test-vault",
+			VaultPath: tmp,
+			ConfigDir: ".obsidian",
+		},
+		Logger: testLogger(),
+	}
+}
+
+func lockFileFor(tmp string) string {
+	return filepath.Join(tmp, ".obsidian", ".sync.lock", "test-vault.lock")
+}
+
+func TestAcquireLockSuccess(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+
+	unlock, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("expected lock acquisition to succeed, got error: %v", err)
+	}
+
+	lockFile := lockFileFor(tmp)
+	if _, err := os.Stat(lockFile); os.IsNotExist(err) {
+		t.Fatalf("expected lock file to exist at %s", lockFile)
+	}
+
+	unlock()
+
+	if _, err := os.Stat(lockFile); !os.IsNotExist(err) {
+		t.Fatal("expected lock file to be removed after unlock")
+	}
+}
+
+func TestAcquireLockExclusive(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+
+	unlock, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("first lock acquisition failed: %v", err)
+	}
+	defer unlock()
+
+	_, err = e.acquireLock()
+	if err == nil {
+		t.Fatal("expected second lock acquisition to fail, but it succeeded")
+	}
+}
+
+func TestAcquireLockConcurrent(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+
+	unlock, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("first lock acquisition failed: %v", err)
+	}
+	defer unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.acquireLock()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected concurrent lock acquisition to fail")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for concurrent lock acquisition")
+	}
+}
+
+func TestAcquireLockReacquireAfterUnlock(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+
+	unlock1, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("first lock acquisition failed: %v", err)
+	}
+	unlock1()
+
+	unlock2, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("second lock acquisition after unlock failed: %v", err)
+	}
+	unlock2()
+}
+
+func TestAcquireLockStaleLockRecovery(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+	lockFile := lockFileFor(tmp)
+
+	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockFile, []byte("old lock"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-staleLockAge - time.Hour)
+	if err := os.Chtimes(lockFile, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := e.acquireLock()
+	if err != nil {
+		t.Fatalf("expected lock acquisition to succeed with stale lock recovery, got error: %v", err)
+	}
+	unlock()
+}
+
+func TestAcquireLockFreshLockBlocksStaleRecovery(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	e := newTestEngine(t, tmp)
+	lockFile := lockFileFor(tmp)
+
+	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockFile, []byte("fresh lock"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := e.acquireLock()
+	if err == nil {
+		t.Fatal("expected lock acquisition to fail with fresh lock file")
+	}
+}

--- a/src/internal/sync/plan.go
+++ b/src/internal/sync/plan.go
@@ -3,8 +3,8 @@ package sync
 import (
 	"sort"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/util"
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/util"
 )
 
 type syncActionKind int

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/Belphemur/obsidian-headless/internal/model"
-	watchpkg "github.com/Belphemur/obsidian-headless/internal/sync/watch"
 )
 
 // RemoteRenameResult holds the outcome of applyRemoteRenameFixups.
@@ -15,7 +14,7 @@ import (
 // Enacted lists the rename operations that were successfully performed on disk.
 type RemoteRenameResult struct {
 	Conflicts []string
-	Enacted   []watchpkg.RenamePair
+	Enacted   []model.RenamePair
 }
 
 // applyRemoteRenameFixups detects remote renames by correlating deleted and active
@@ -24,7 +23,7 @@ type RemoteRenameResult struct {
 //  2. The local file at oldPath is os.Rename'd to newPath if it exists and is unmodified
 //  3. The deleted entry is removed from currentRemote
 //
-// Returns (*RemoteRenameResult, nil) — the function never returns an error.
+// Returns *RemoteRenameResult — the function never returns an error.
 // Rename failures are recorded as Conflicts in the result rather than returned as errors.
 func applyRemoteRenameFixups(
 	currentRemote map[string]model.FileRecord,
@@ -33,7 +32,7 @@ func applyRemoteRenameFixups(
 	currentLocal map[string]model.FileRecord,
 	vaultPath string,
 	logger zerolog.Logger,
-) (*RemoteRenameResult, error) {
+) *RemoteRenameResult {
 	result := &RemoteRenameResult{}
 
 	// Step 1: In a single pass, collect deleted UIDs and active UID→newPath mappings.
@@ -52,7 +51,7 @@ func applyRemoteRenameFixups(
 
 	// Guard: nothing to correlate.
 	if len(deletedUIDs) == 0 {
-		return result, nil
+		return result
 	}
 
 	// Step 2: Correlate deleted UIDs with active UIDs to find renames.
@@ -131,7 +130,7 @@ func applyRemoteRenameFixups(
 					currentLocal[newPath] = oldLocal
 					delete(currentLocal, oldPath)
 
-					result.Enacted = append(result.Enacted, watchpkg.RenamePair{OldPath: oldPath, NewPath: newPath})
+					result.Enacted = append(result.Enacted, model.RenamePair{OldPath: oldPath, NewPath: newPath})
 					renameEnacted = true
 					logger.Info().
 						Str("oldPath", oldPath).
@@ -163,5 +162,5 @@ func applyRemoteRenameFixups(
 		// independently.
 	}
 
-	return result, nil
+	return result
 }

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -24,8 +24,8 @@ type RemoteRenameResult struct {
 //  2. The local file at oldPath is os.Rename'd to newPath if it exists and is unmodified
 //  3. The deleted entry is removed from currentRemote
 //
-// Returns (nil, error) only on fatal error (e.g. os.Rename failure).
-// Returns (*RemoteRenameResult, nil) on success with possible Conflicts.
+// Returns (*RemoteRenameResult, nil) — the function never returns an error.
+// Rename failures are recorded as Conflicts in the result rather than returned as errors.
 func applyRemoteRenameFixups(
 	currentRemote map[string]model.FileRecord,
 	previousRemote map[string]model.FileRecord,
@@ -36,36 +36,26 @@ func applyRemoteRenameFixups(
 ) (*RemoteRenameResult, error) {
 	result := &RemoteRenameResult{}
 
-	// Step 1: Scan for deleted entries with UIDs in currentRemote
-	deletedUIDs := make(map[int64]string) // uid → oldPath
+	// Step 1: In a single pass, collect deleted UIDs and active UID→newPath mappings.
+	deletedUIDs := make(map[int64]string)  // uid → oldPath
+	uidToNewPath := make(map[int64]string) // uid → newPath
 	for path, record := range currentRemote {
-		if !record.Deleted || record.Folder {
+		if record.Folder || record.UID == 0 {
 			continue
 		}
-		if record.UID == 0 {
-			continue
+		if record.Deleted {
+			deletedUIDs[record.UID] = path
+		} else {
+			uidToNewPath[record.UID] = path
 		}
-		deletedUIDs[record.UID] = path
 	}
 
-	// Guard: no deleted entries to correlate
+	// Guard: nothing to correlate.
 	if len(deletedUIDs) == 0 {
 		return result, nil
 	}
 
-	// Step 2: Build UID→newPath map from active entries in currentRemote
-	uidToNewPath := make(map[int64]string) // uid → newPath
-	for path, record := range currentRemote {
-		if record.Deleted || record.Folder {
-			continue
-		}
-		if record.UID == 0 {
-			continue
-		}
-		uidToNewPath[record.UID] = path
-	}
-
-	// Step 3: Correlate deleted UIDs with active UIDs to find renames
+	// Step 2: Correlate deleted UIDs with active UIDs to find renames.
 	for uid, oldPath := range deletedUIDs {
 		newPath, ok := uidToNewPath[uid]
 		if !ok || newPath == oldPath {
@@ -79,7 +69,7 @@ func applyRemoteRenameFixups(
 			Int64("uid", uid).
 			Msg("remote rename detected via UID match")
 
-		// Step 3a: Handle local file at oldPath
+		// Step 2a: Handle local file at oldPath
 		oldLocal, hasOldLocal := currentLocal[oldPath]
 		renameEnacted := false
 		if hasOldLocal {
@@ -88,8 +78,21 @@ func applyRemoteRenameFixups(
 
 			// Check if local file was modified
 			localModified := false
-			if prevLocal, hasPrevLocal := previousLocal[oldPath]; hasPrevLocal {
-				localModified = oldLocal.Hash != prevLocal.Hash
+			_, hasPrevLocal := previousLocal[oldPath]
+			if hasPrevLocal {
+				localModified = oldLocal.Hash != previousLocal[oldPath].Hash
+			}
+
+			// If neither previousLocal nor previousRemote has oldPath, can't verify
+			// the local file corresponds to the remote file — treat as conflict.
+			if !hasPrevLocal {
+				if _, hasPrevRemote := previousRemote[oldPath]; !hasPrevRemote {
+					logger.Warn().
+						Str("oldPath", oldPath).
+						Msg("remote rename: no previous state for oldPath, preserving local file")
+					result.Conflicts = append(result.Conflicts, oldPath)
+					continue
+				}
 			}
 
 			if localModified {
@@ -109,7 +112,13 @@ func applyRemoteRenameFixups(
 				result.Conflicts = append(result.Conflicts, oldPath)
 			} else {
 				// Local file is unmodified and destination is clear → rename it on disk
-				if err := os.Rename(localPath, newLocalPath); err != nil {
+				if err := os.MkdirAll(filepath.Dir(newLocalPath), 0o755); err != nil {
+					logger.Error().
+						Err(err).
+						Str("newPath", newPath).
+						Msg("remote rename: os.MkdirAll failed, treating as conflict")
+					result.Conflicts = append(result.Conflicts, oldPath)
+				} else if err := os.Rename(localPath, newLocalPath); err != nil {
 					logger.Error().
 						Err(err).
 						Str("oldPath", oldPath).
@@ -133,7 +142,7 @@ func applyRemoteRenameFixups(
 		}
 		// else: local file already absent → nothing to rename on disk
 
-		// Step 3b: Update metadata state — only if the rename was enacted on disk
+		// Step 2b: Update metadata state — only if the rename was enacted on disk
 		// or the local file was already absent (rename happened on another device).
 		if renameEnacted || !hasOldLocal {
 			// Update previousRemote to reflect the rename

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -1,0 +1,158 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog"
+
+	"github.com/Belphemur/obsidian-headless/internal/model"
+	watchpkg "github.com/Belphemur/obsidian-headless/internal/sync/watch"
+)
+
+// RemoteRenameResult holds the outcome of applyRemoteRenameFixups.
+// Conflicts lists paths of locally modified files that were preserved (not renamed).
+// Enacted lists the rename operations that were successfully performed on disk.
+type RemoteRenameResult struct {
+	Conflicts []string
+	Enacted   []watchpkg.RenamePair
+}
+
+// applyRemoteRenameFixups detects remote renames by correlating deleted and active
+// entries in currentRemote that share the same UID. When a rename is found:
+//  1. previousRemote is mutated to reflect the rename (PreviousPath set, record moved)
+//  2. The local file at oldPath is os.Rename'd to newPath if it exists and is unmodified
+//  3. The deleted entry is removed from currentRemote
+//
+// Returns (nil, error) only on fatal error (e.g. os.Rename failure).
+// Returns (*RemoteRenameResult, nil) on success with possible Conflicts.
+func applyRemoteRenameFixups(
+	currentRemote map[string]model.FileRecord,
+	previousRemote map[string]model.FileRecord,
+	previousLocal map[string]model.FileRecord,
+	currentLocal map[string]model.FileRecord,
+	vaultPath string,
+	logger zerolog.Logger,
+) (*RemoteRenameResult, error) {
+	result := &RemoteRenameResult{}
+
+	// Step 1: Scan for deleted entries with UIDs in currentRemote
+	deletedUIDs := make(map[int64]string) // uid → oldPath
+	for path, record := range currentRemote {
+		if !record.Deleted || record.Folder {
+			continue
+		}
+		if record.UID == 0 {
+			continue
+		}
+		deletedUIDs[record.UID] = path
+	}
+
+	// Guard: no deleted entries to correlate
+	if len(deletedUIDs) == 0 {
+		return result, nil
+	}
+
+	// Step 2: Build UID→newPath map from active entries in currentRemote
+	uidToNewPath := make(map[int64]string) // uid → newPath
+	for path, record := range currentRemote {
+		if record.Deleted || record.Folder {
+			continue
+		}
+		if record.UID == 0 {
+			continue
+		}
+		uidToNewPath[record.UID] = path
+	}
+
+	// Step 3: Correlate deleted UIDs with active UIDs to find renames
+	for uid, oldPath := range deletedUIDs {
+		newPath, ok := uidToNewPath[uid]
+		if !ok || newPath == oldPath {
+			continue
+		}
+
+		// Remote rename detected: oldPath → newPath
+		logger.Info().
+			Str("oldPath", oldPath).
+			Str("newPath", newPath).
+			Int64("uid", uid).
+			Msg("remote rename detected via UID match")
+
+		// Step 3a: Handle local file at oldPath
+		oldLocal, hasOldLocal := currentLocal[oldPath]
+		renameEnacted := false
+		if hasOldLocal {
+			localPath := filepath.Join(vaultPath, oldPath)
+			newLocalPath := filepath.Join(vaultPath, newPath)
+
+			// Check if local file was modified
+			localModified := false
+			if prevLocal, hasPrevLocal := previousLocal[oldPath]; hasPrevLocal {
+				localModified = oldLocal.Hash != prevLocal.Hash
+			}
+
+			if localModified {
+				// Local file was modified → preserve it, don't rename
+				logger.Warn().
+					Str("oldPath", oldPath).
+					Str("localHash", oldLocal.Hash).
+					Str("prevHash", previousLocal[oldPath].Hash).
+					Msg("remote rename: local file modified, preserving")
+				result.Conflicts = append(result.Conflicts, oldPath)
+			} else if _, exists := currentLocal[newPath]; exists {
+				// Destination already exists locally
+				logger.Warn().
+					Str("oldPath", oldPath).
+					Str("newPath", newPath).
+					Msg("remote rename: destination exists locally, preserving")
+				result.Conflicts = append(result.Conflicts, oldPath)
+			} else {
+				// Local file is unmodified and destination is clear → rename it on disk
+				if err := os.Rename(localPath, newLocalPath); err != nil {
+					logger.Error().
+						Err(err).
+						Str("oldPath", oldPath).
+						Str("newPath", newPath).
+						Msg("remote rename: os.Rename failed, treating as conflict")
+					result.Conflicts = append(result.Conflicts, oldPath)
+				} else {
+					// Rename succeeded on disk
+					oldLocal.Path = newPath
+					currentLocal[newPath] = oldLocal
+					delete(currentLocal, oldPath)
+
+					result.Enacted = append(result.Enacted, watchpkg.RenamePair{OldPath: oldPath, NewPath: newPath})
+					renameEnacted = true
+					logger.Info().
+						Str("oldPath", oldPath).
+						Str("newPath", newPath).
+						Msg("remote rename: local file renamed on disk")
+				}
+			}
+		}
+		// else: local file already absent → nothing to rename on disk
+
+		// Step 3b: Update metadata state — only if the rename was enacted on disk
+		// or the local file was already absent (rename happened on another device).
+		if renameEnacted || !hasOldLocal {
+			// Update previousRemote to reflect the rename
+			if oldRemote, exists := previousRemote[oldPath]; exists {
+				oldRemote.PreviousPath = oldPath
+				oldRemote.Path = newPath
+				previousRemote[newPath] = oldRemote
+				delete(previousRemote, oldPath)
+			}
+
+			// Remove the deleted entry from currentRemote so buildPlan
+			// doesn't emit a deleteLocal action for oldPath.
+			delete(currentRemote, oldPath)
+		}
+		// If !renameEnacted && hasOldLocal: local file exists but rename was
+		// blocked (modified, dest exists, or rename failed). Don't mutate
+		// previousRemote or currentRemote — let buildPlan handle both paths
+		// independently.
+	}
+
+	return result, nil
+}

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -19,9 +19,11 @@ type RemoteRenameResult struct {
 
 // applyRemoteRenameFixups detects remote renames by correlating deleted and active
 // entries in currentRemote that share the same UID. When a rename is found:
-//  1. previousRemote is mutated to reflect the rename (PreviousPath set, record moved)
-//  2. The local file at oldPath is os.Rename'd to newPath if it exists and is unmodified
-//  3. The deleted entry is removed from currentRemote
+//  1. onBeforeRename is called (if non-nil) to allow the caller to suppress watcher
+//     events for oldPath and newPath before the filesystem rename occurs.
+//  2. previousRemote is mutated to reflect the rename (PreviousPath set, record moved)
+//  3. The local file at oldPath is os.Rename'd to newPath if it exists and is unmodified
+//  4. The deleted entry is removed from currentRemote
 //
 // Returns *RemoteRenameResult — the function never returns an error.
 // Rename failures are recorded as Conflicts in the result rather than returned as errors.
@@ -32,6 +34,7 @@ func applyRemoteRenameFixups(
 	currentLocal map[string]model.FileRecord,
 	vaultPath string,
 	logger zerolog.Logger,
+	onBeforeRename func(model.RenamePair),
 ) *RemoteRenameResult {
 	result := &RemoteRenameResult{}
 
@@ -110,33 +113,39 @@ func applyRemoteRenameFixups(
 					Msg("remote rename: destination exists locally, preserving")
 				result.Conflicts = append(result.Conflicts, oldPath)
 			} else {
-				// Local file is unmodified and destination is clear → rename it on disk
-				if err := os.MkdirAll(filepath.Dir(newLocalPath), 0o755); err != nil {
-					logger.Error().
-						Err(err).
-						Str("newPath", newPath).
-						Msg("remote rename: os.MkdirAll failed, treating as conflict")
-					result.Conflicts = append(result.Conflicts, oldPath)
-				} else if err := os.Rename(localPath, newLocalPath); err != nil {
-					logger.Error().
-						Err(err).
-						Str("oldPath", oldPath).
-						Str("newPath", newPath).
-						Msg("remote rename: os.Rename failed, treating as conflict")
-					result.Conflicts = append(result.Conflicts, oldPath)
-				} else {
-					// Rename succeeded on disk
-					oldLocal.Path = newPath
-					currentLocal[newPath] = oldLocal
-					delete(currentLocal, oldPath)
+			// Local file is unmodified and destination is clear → rename it on disk.
+			// Register the ignore pair before the filesystem rename to prevent
+			// the watcher from seeing our own rename as a user-initiated change.
+			pair := model.RenamePair{OldPath: oldPath, NewPath: newPath}
+			if onBeforeRename != nil {
+				onBeforeRename(pair)
+			}
+			if err := os.MkdirAll(filepath.Dir(newLocalPath), 0o755); err != nil {
+				logger.Error().
+					Err(err).
+					Str("newPath", newPath).
+					Msg("remote rename: os.MkdirAll failed, treating as conflict")
+				result.Conflicts = append(result.Conflicts, oldPath)
+			} else if err := os.Rename(localPath, newLocalPath); err != nil {
+				logger.Error().
+					Err(err).
+					Str("oldPath", oldPath).
+					Str("newPath", newPath).
+					Msg("remote rename: os.Rename failed, treating as conflict")
+				result.Conflicts = append(result.Conflicts, oldPath)
+			} else {
+				// Rename succeeded on disk
+				oldLocal.Path = newPath
+				currentLocal[newPath] = oldLocal
+				delete(currentLocal, oldPath)
 
-					result.Enacted = append(result.Enacted, model.RenamePair{OldPath: oldPath, NewPath: newPath})
-					renameEnacted = true
-					logger.Info().
-						Str("oldPath", oldPath).
-						Str("newPath", newPath).
-						Msg("remote rename: local file renamed on disk")
-				}
+				result.Enacted = append(result.Enacted, pair)
+				renameEnacted = true
+				logger.Info().
+					Str("oldPath", oldPath).
+					Str("newPath", newPath).
+					Msg("remote rename: local file renamed on disk")
+			}
 			}
 		}
 		// else: local file already absent → nothing to rename on disk

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -44,10 +44,7 @@ func TestApplyRemoteRenameFixups_BasicRename(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 
 	// Check result
 	if len(result.Enacted) != 1 {
@@ -113,10 +110,7 @@ func TestApplyRemoteRenameFixups_NoRename_DifferentUIDs(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames, got %d", len(result.Enacted))
 	}
@@ -135,7 +129,7 @@ func TestApplyRemoteRenameFixups_EmptyMaps(t *testing.T) {
 	defer cleanup()
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(
+	result := applyRemoteRenameFixups(
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
@@ -143,9 +137,6 @@ func TestApplyRemoteRenameFixups_EmptyMaps(t *testing.T) {
 		vaultPath,
 		logger,
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames from empty maps")
 	}
@@ -183,10 +174,7 @@ func TestApplyRemoteRenameFixups_LocalModified(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 
 	// Should NOT enact rename (local modified)
 	if len(result.Enacted) != 0 {
@@ -224,10 +212,7 @@ func TestApplyRemoteRenameFixups_FolderRecordsExcluded(t *testing.T) {
 	currentLocal := map[string]model.FileRecord{}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames (folders excluded), got %d", len(result.Enacted))
 	}
@@ -250,10 +235,7 @@ func TestApplyRemoteRenameFixups_NoUID(t *testing.T) {
 	currentLocal := map[string]model.FileRecord{}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames (UID=0 skipped)")
 	}
@@ -271,15 +253,12 @@ func TestApplyRemoteRenameFixups_SamePath(t *testing.T) {
 	}
 	// No deleted entry → should be no-op
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote,
+	result := applyRemoteRenameFixups(currentRemote,
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
 		vaultPath, logger,
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames")
 	}
@@ -320,10 +299,7 @@ func TestApplyRemoteRenameFixups_DestinationExists(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 
 	// Should NOT enact rename (destination exists)
 	if len(result.Enacted) != 0 {
@@ -390,10 +366,7 @@ func TestApplyRemoteRenameFixups_RenameError(t *testing.T) {
 	}()
 
 	logger := zerolog.Nop()
-	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
-	if err != nil {
-		t.Fatalf("expected nil error on rename failure, got: %v", err)
-	}
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames, got %d", len(result.Enacted))
 	}

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -1,0 +1,406 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/Belphemur/obsidian-headless/internal/model"
+)
+
+func setupRenameTest(t *testing.T) (string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	return dir, func() {}
+}
+
+func TestApplyRemoteRenameFixups_BasicRename(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Setup: remote renamed "old.md" → "new.md"
+	uid := int64(42)
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: uid, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: uid, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: uid},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: uid},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+
+	// Create the local file so os.Rename can succeed
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	if err := os.WriteFile(localOldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check result
+	if len(result.Enacted) != 1 {
+		t.Fatalf("expected 1 enacted rename, got %d", len(result.Enacted))
+	}
+	if result.Enacted[0].OldPath != "old.md" || result.Enacted[0].NewPath != "new.md" {
+		t.Fatalf("unexpected rename pair: %+v", result.Enacted[0])
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+
+	// Check previousRemote was mutated
+	if _, exists := previousRemote["old.md"]; exists {
+		t.Error("old.md should have been removed from previousRemote")
+	}
+	if prev, exists := previousRemote["new.md"]; !exists {
+		t.Error("new.md should be in previousRemote")
+	} else if prev.PreviousPath != "old.md" {
+		t.Errorf("expected PreviousPath 'old.md', got '%s'", prev.PreviousPath)
+	}
+
+	// Check currentRemote: old path should be deleted
+	if _, exists := currentRemote["old.md"]; exists {
+		t.Error("old.md should have been removed from currentRemote")
+	}
+
+	// Check currentLocal: old path should be moved to new path
+	if _, exists := currentLocal["old.md"]; exists {
+		t.Error("old.md should have been removed from currentLocal")
+	}
+	if _, exists := currentLocal["new.md"]; !exists {
+		t.Error("new.md should be in currentLocal")
+	}
+
+	// Check the file was actually renamed on disk
+	if _, err := os.Stat(filepath.Join(vaultPath, "old.md")); !os.IsNotExist(err) {
+		t.Error("old.md should not exist on disk after rename")
+	}
+	if _, err := os.Stat(filepath.Join(vaultPath, "new.md")); err != nil {
+		t.Error("new.md should exist on disk after rename")
+	}
+}
+
+func TestApplyRemoteRenameFixups_NoRename_DifferentUIDs(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// UIDs don't match → no rename
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: 42, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: 99, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "xyz", UID: 99},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "xyz", UID: 99},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "xyz"},
+	}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected no enacted renames, got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected no conflicts, got %d", len(result.Conflicts))
+	}
+	// currentRemote should still have old.md (not deleted)
+	if _, exists := currentRemote["old.md"]; !exists {
+		t.Error("old.md should still be in currentRemote (different UIDs, not a rename)")
+	}
+}
+
+func TestApplyRemoteRenameFixups_EmptyMaps(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(
+		map[string]model.FileRecord{},
+		map[string]model.FileRecord{},
+		map[string]model.FileRecord{},
+		map[string]model.FileRecord{},
+		vaultPath,
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected no enacted renames from empty maps")
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected no conflicts from empty maps")
+	}
+}
+
+func TestApplyRemoteRenameFixups_LocalModified(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	uid := int64(42)
+	// Remote renamed: old.md → new.md
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: uid, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: uid, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: uid},
+	}
+	// Local has a DIFFERENT hash (modified)
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "modified-hash"},
+	}
+
+	// Create the local file
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	if err := os.WriteFile(localOldPath, []byte("modified content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT enact rename (local modified)
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (local modified), got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(result.Conflicts))
+	}
+	if result.Conflicts[0] != "old.md" {
+		t.Fatalf("expected conflict path 'old.md', got '%s'", result.Conflicts[0])
+	}
+
+	// old.md should still exist on disk (not renamed)
+	if _, err := os.Stat(localOldPath); err != nil {
+		t.Error("old.md should still exist on disk (local modified, preserved)")
+	}
+	// old.md should still be in currentLocal
+	if _, exists := currentLocal["old.md"]; !exists {
+		t.Error("old.md should still be in currentLocal")
+	}
+}
+
+func TestApplyRemoteRenameFixups_FolderRecordsExcluded(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	uid := int64(42)
+	currentRemote := map[string]model.FileRecord{
+		"newfolder/": {Path: "newfolder/", Folder: true, UID: uid, Deleted: false},
+		"oldfolder/": {Path: "oldfolder/", Folder: true, UID: uid, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{}
+	previousLocal := map[string]model.FileRecord{}
+	currentLocal := map[string]model.FileRecord{}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (folders excluded), got %d", len(result.Enacted))
+	}
+}
+
+func TestApplyRemoteRenameFixups_NoUID(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Records with UID=0 should be skipped
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: 0, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: 0, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 0},
+	}
+	previousLocal := map[string]model.FileRecord{}
+	currentLocal := map[string]model.FileRecord{}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (UID=0 skipped)")
+	}
+}
+
+func TestApplyRemoteRenameFixups_SamePath(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Same UID but same path (e.g. file updated, not renamed)
+	uid := int64(42)
+	currentRemote := map[string]model.FileRecord{
+		"file.md": {Path: "file.md", Hash: "abc", UID: uid, Deleted: false},
+	}
+	// No deleted entry → should be no-op
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote,
+		map[string]model.FileRecord{},
+		map[string]model.FileRecord{},
+		map[string]model.FileRecord{},
+		vaultPath, logger,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected no enacted renames")
+	}
+}
+
+func TestApplyRemoteRenameFixups_DestinationExists(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	uid := int64(42)
+	// Remote renamed: old.md → new.md
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: uid, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: uid, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: uid},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+		"new.md": {Path: "new.md", Hash: "existing"},
+	}
+	// Local already has new.md (destination exists)
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+		"new.md": {Path: "new.md", Hash: "existing"},
+	}
+
+	// Create both files on disk
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	localNewPath := filepath.Join(vaultPath, "new.md")
+	if err := os.WriteFile(localOldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(localNewPath, []byte("existing content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT enact rename (destination exists)
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (destination exists), got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(result.Conflicts))
+	}
+	if result.Conflicts[0] != "old.md" {
+		t.Fatalf("expected conflict path 'old.md', got '%s'", result.Conflicts[0])
+	}
+
+	// old.md should still exist on disk (not renamed/overwritten)
+	if _, err := os.Stat(localOldPath); err != nil {
+		t.Error("old.md should still exist on disk")
+	}
+	// new.md should still have its original content
+	content, err := os.ReadFile(localNewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "existing content" {
+		t.Errorf("new.md content was overwritten; got %q, want %q", string(content), "existing content")
+	}
+	// old.md should still be in currentLocal
+	if _, exists := currentLocal["old.md"]; !exists {
+		t.Error("old.md should still be in currentLocal")
+	}
+}
+
+func TestApplyRemoteRenameFixups_RenameError(t *testing.T) {
+	// NOTE: Not parallel because we chmod the temp dir
+	vaultPath := t.TempDir()
+
+	uid := int64(42)
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: uid, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: uid, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: uid},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+
+	// Create the local file
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	if err := os.WriteFile(localOldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make vaultPath read-only to prevent os.Rename from creating new.md
+	if err := os.Chmod(vaultPath, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(vaultPath, 0700) // restore for cleanup
+
+	logger := zerolog.Nop()
+	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	if err != nil {
+		t.Fatalf("expected nil error on rename failure, got: %v", err)
+	}
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames, got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict on rename failure, got %d", len(result.Conflicts))
+	}
+	if result.Conflicts[0] != "old.md" {
+		t.Fatalf("expected conflict 'old.md', got '%s'", result.Conflicts[0])
+	}
+	// currentRemote should still have old.md (not deleted, since rename failed)
+	if _, exists := currentRemote["old.md"]; !exists {
+		t.Error("old.md should remain in currentRemote after rename failure")
+	}
+}

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -44,7 +44,7 @@ func TestApplyRemoteRenameFixups_BasicRename(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 
 	// Check result
 	if len(result.Enacted) != 1 {
@@ -110,7 +110,7 @@ func TestApplyRemoteRenameFixups_NoRename_DifferentUIDs(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames, got %d", len(result.Enacted))
 	}
@@ -135,7 +135,7 @@ func TestApplyRemoteRenameFixups_EmptyMaps(t *testing.T) {
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
 		vaultPath,
-		logger,
+		logger, nil,
 	)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames from empty maps")
@@ -174,7 +174,7 @@ func TestApplyRemoteRenameFixups_LocalModified(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 
 	// Should NOT enact rename (local modified)
 	if len(result.Enacted) != 0 {
@@ -212,7 +212,7 @@ func TestApplyRemoteRenameFixups_FolderRecordsExcluded(t *testing.T) {
 	currentLocal := map[string]model.FileRecord{}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames (folders excluded), got %d", len(result.Enacted))
 	}
@@ -235,7 +235,7 @@ func TestApplyRemoteRenameFixups_NoUID(t *testing.T) {
 	currentLocal := map[string]model.FileRecord{}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames (UID=0 skipped)")
 	}
@@ -257,7 +257,7 @@ func TestApplyRemoteRenameFixups_SamePath(t *testing.T) {
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
 		map[string]model.FileRecord{},
-		vaultPath, logger,
+		vaultPath, logger, nil,
 	)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected no enacted renames")
@@ -299,7 +299,7 @@ func TestApplyRemoteRenameFixups_DestinationExists(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 
 	// Should NOT enact rename (destination exists)
 	if len(result.Enacted) != 0 {
@@ -366,7 +366,7 @@ func TestApplyRemoteRenameFixups_RenameError(t *testing.T) {
 	}()
 
 	logger := zerolog.Nop()
-	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
 	if len(result.Enacted) != 0 {
 		t.Fatalf("expected 0 enacted renames, got %d", len(result.Enacted))
 	}

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -383,7 +383,11 @@ func TestApplyRemoteRenameFixups_RenameError(t *testing.T) {
 	if err := os.Chmod(vaultPath, 0500); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(vaultPath, 0700) // restore for cleanup
+	defer func() {
+		if err := os.Chmod(vaultPath, 0700); err != nil {
+			t.Errorf("failed to restore permissions: %v", err)
+		}
+	}()
 
 	logger := zerolog.Nop()
 	result, err := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger)

--- a/src/internal/sync/session.go
+++ b/src/internal/sync/session.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/encryption"
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/encryption"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 type remoteSession struct {

--- a/src/internal/sync/watch/event.go
+++ b/src/internal/sync/watch/event.go
@@ -35,11 +35,3 @@ type ScanEvent struct {
 	DetectedAt time.Time
 	OldPath    string // previous path; only valid when Type == EventRename
 }
-
-// RenamePair represents an old→new path pair for a rename operation.
-// Used between sync/ and watch/ packages to communicate rename paths
-// without circular imports (sync imports watch, not vice versa).
-type RenamePair struct {
-	OldPath string
-	NewPath string
-}

--- a/src/internal/sync/watch/event.go
+++ b/src/internal/sync/watch/event.go
@@ -35,3 +35,11 @@ type ScanEvent struct {
 	DetectedAt time.Time
 	OldPath    string // previous path; only valid when Type == EventRename
 }
+
+// RenamePair represents an old→new path pair for a rename operation.
+// Used between sync/ and watch/ packages to communicate rename paths
+// without circular imports (sync imports watch, not vice versa).
+type RenamePair struct {
+	OldPath string
+	NewPath string
+}

--- a/src/internal/sync/watch/watcher.go
+++ b/src/internal/sync/watch/watcher.go
@@ -391,13 +391,34 @@ func (w *Watcher) isIgnored(path string) bool {
 // After a remote rename is enacted on disk, the resulting filesystem events
 // must be suppressed to prevent the watcher from interpreting them as new
 // user-initiated renames in the next sync cycle.
+//
+// Paths are normalized to the same relative-slash form used by isIgnored,
+// ensuring that equivalent paths (e.g., "./a/b.md", "a/b.md") match the
+// suppression lookup regardless of caller format.
 func (w *Watcher) AddIgnorePaths(pairs []RenamePair) {
 	w.ignoreMu.Lock()
 	defer w.ignoreMu.Unlock()
 	for _, p := range pairs {
-		w.ignoredOld[p.OldPath] = true
-		w.ignoredNew[p.NewPath] = true
+		if old := normalizeIgnoreKey(p.OldPath); old != "" {
+			w.ignoredOld[old] = true
+		}
+		if newPath := normalizeIgnoreKey(p.NewPath); newPath != "" {
+			w.ignoredNew[newPath] = true
+		}
 	}
+}
+
+// normalizeIgnoreKey converts a relative path to the normalized form used
+// by isIgnored for consistent map lookups: forward slashes, no leading "./"
+// or "/", cleaned relative form.
+func normalizeIgnoreKey(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	path = strings.TrimPrefix(path, "./")
+	path = strings.TrimPrefix(path, "/")
+	if path == "." {
+		return ""
+	}
+	return path
 }
 
 // FlushIgnored clears all ignored paths. Called at the start of each

--- a/src/internal/sync/watch/watcher.go
+++ b/src/internal/sync/watch/watcher.go
@@ -40,6 +40,9 @@ type Watcher struct {
 	inodeTrackingEnabled bool
 	pendingRenames       map[uint64]*pendingRename
 	pendingRenamePaths   map[string]uint64
+	ignoreMu             sync.Mutex
+	ignoredOld           map[string]bool // old paths to suppress events for
+	ignoredNew           map[string]bool // new paths to suppress events for
 }
 
 func New(root string, excludes []string, logger zerolog.Logger, rescanInterval time.Duration) (*Watcher, error) {
@@ -61,6 +64,8 @@ func New(root string, excludes []string, logger zerolog.Logger, rescanInterval t
 	watcher.inodeTrackingEnabled = runtime.GOOS != "windows"
 	watcher.pendingRenames = make(map[uint64]*pendingRename)
 	watcher.pendingRenamePaths = make(map[string]uint64)
+	watcher.ignoredOld = make(map[string]bool)
+	watcher.ignoredNew = make(map[string]bool)
 	if err := watcher.addDirsRecursive(root); err != nil {
 		_ = fw.Close()
 		return nil, err
@@ -102,6 +107,12 @@ func (w *Watcher) Run(ctx context.Context) {
 func (w *Watcher) handle(event fsnotify.Event) {
 	w.logger.Debug().Str("path", event.Name).Str("ops", event.Op.String()).Msg("fs event")
 	if w.isExcluded(event.Name) {
+		return
+	}
+
+	// Suppress events for paths added via AddIgnorePaths (remote rename aftermath)
+	if w.isIgnored(event.Name) {
+		w.logger.Debug().Str("path", event.Name).Msg("suppressing event for ignored path")
 		return
 	}
 
@@ -354,6 +365,48 @@ func (w *Watcher) shutdown(ctx context.Context) {
 		w.logger.Warn().Msg("skipping final watcher flush during shutdown because cancellation fired first")
 	}
 	close(w.Out)
+}
+
+// isIgnored checks whether events for the given path should be suppressed.
+// Must be called with ignoreMu NOT held (it acquires the lock internally).
+func (w *Watcher) isIgnored(path string) bool {
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return false
+	}
+	w.ignoreMu.Lock()
+	defer w.ignoreMu.Unlock()
+	// Check both old and new ignore sets
+	if w.ignoredOld[rel] || w.ignoredNew[rel] {
+		return true
+	}
+	return false
+}
+
+// AddIgnorePaths suppresses fsnotify events for the given rename pairs.
+// After a remote rename is enacted on disk, the resulting filesystem events
+// must be suppressed to prevent the watcher from interpreting them as new
+// user-initiated renames in the next sync cycle.
+func (w *Watcher) AddIgnorePaths(pairs []RenamePair) {
+	w.ignoreMu.Lock()
+	defer w.ignoreMu.Unlock()
+	for _, p := range pairs {
+		w.ignoredOld[p.OldPath] = true
+		w.ignoredNew[p.NewPath] = true
+	}
+}
+
+// FlushIgnored clears all ignored paths. Called at the start of each
+// doSync cycle so ignorations don't persist across sync cycles.
+func (w *Watcher) FlushIgnored() {
+	w.ignoreMu.Lock()
+	defer w.ignoreMu.Unlock()
+	clear(w.ignoredOld)
+	clear(w.ignoredNew)
 }
 
 func (w *Watcher) isExcluded(path string) bool {

--- a/src/internal/sync/watch/watcher.go
+++ b/src/internal/sync/watch/watcher.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/rs/zerolog"
+
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 const eventBufSize = 1024
@@ -395,7 +397,7 @@ func (w *Watcher) isIgnored(path string) bool {
 // Paths are normalized to the same relative-slash form used by isIgnored,
 // ensuring that equivalent paths (e.g., "./a/b.md", "a/b.md") match the
 // suppression lookup regardless of caller format.
-func (w *Watcher) AddIgnorePaths(pairs []RenamePair) {
+func (w *Watcher) AddIgnorePaths(pairs []model.RenamePair) {
 	w.ignoreMu.Lock()
 	defer w.ignoreMu.Unlock()
 	for _, p := range pairs {
@@ -409,12 +411,11 @@ func (w *Watcher) AddIgnorePaths(pairs []RenamePair) {
 }
 
 // normalizeIgnoreKey converts a relative path to the normalized form used
-// by isIgnored for consistent map lookups: forward slashes, no leading "./"
-// or "/", cleaned relative form.
+// by isIgnored for consistent map lookups. Uses stdlib filepath.Clean
+// (which resolves ".", "./", "//", etc.) + filepath.ToSlash for cross-
+// platform forward-slash keys matching isIgnored's filepath.Rel output.
 func normalizeIgnoreKey(path string) string {
 	path = filepath.ToSlash(filepath.Clean(path))
-	path = strings.TrimPrefix(path, "./")
-	path = strings.TrimPrefix(path, "/")
 	if path == "." {
 		return ""
 	}

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/Belphemur/obsidian-headless/internal/model"
 )
 
 func testLogger(t *testing.T) zerolog.Logger {
@@ -195,7 +197,7 @@ func TestWatcher_IgnorePaths_SuppressesRemove(t *testing.T) {
 	})
 
 	// Now add old path to ignored set
-	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+	w.AddIgnorePaths([]model.RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
 
 	// Now simulate a remove by the remote rename fixup
 	if err := os.Remove(filePath); err != nil {
@@ -222,7 +224,7 @@ func TestWatcher_IgnorePaths_SuppressesCreate(t *testing.T) {
 	go w.Run(ctx)
 
 	// Add new path to ignored set
-	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+	w.AddIgnorePaths([]model.RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
 
 	// Create file at new path (simulating remote rename creating new.md)
 	filePath := filepath.Join(dir, "new.md")
@@ -250,7 +252,7 @@ func TestWatcher_IgnorePaths_NotSuppressedWhenUnrelated(t *testing.T) {
 	go w.Run(ctx)
 
 	// Add some paths to ignored set
-	w.AddIgnorePaths([]RenamePair{{OldPath: "ignored-old.md", NewPath: "ignored-new.md"}})
+	w.AddIgnorePaths([]model.RenamePair{{OldPath: "ignored-old.md", NewPath: "ignored-new.md"}})
 
 	// Create an UNRELATED file
 	filePath := filepath.Join(dir, "normal.md")
@@ -280,7 +282,7 @@ func TestWatcher_IgnorePaths_FlushIgnored(t *testing.T) {
 	go w.Run(ctx)
 
 	// Add path to ignored set, then flush
-	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+	w.AddIgnorePaths([]model.RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
 	w.FlushIgnored()
 
 	// Now create file at new path — should NOT be suppressed (flush cleared it)

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -189,12 +189,10 @@ func TestWatcher_IgnorePaths_SuppressesRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Drain initial create event
-	select {
-	case <-w.Out:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for initial create event")
-	}
+	// Drain initial create event — verify both event type and path (watcher emits absolute paths)
+	_ = waitForEvent(t, w.Out, 5*time.Second, "initial create for old.md", func(ev ScanEvent) bool {
+		return ev.Type == EventCreate && ev.Path == filePath
+	})
 
 	// Now add old path to ignored set
 	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -54,6 +54,7 @@ func TestWatcher_RenameDetection(t *testing.T) {
 	ctx := t.Context()
 
 	go w.Run(ctx)
+	time.Sleep(50 * time.Millisecond) // let watcher goroutine enter event loop
 
 	// Create initial file
 	oldPath := filepath.Join(root, "old.md")
@@ -101,6 +102,7 @@ func TestWatcher_RealDeletion_NoMatchingCreate(t *testing.T) {
 	ctx := t.Context()
 
 	go w.Run(ctx)
+	time.Sleep(50 * time.Millisecond) // let watcher goroutine enter event loop
 
 	// Create file
 	path := filepath.Join(root, "temp.md")
@@ -145,6 +147,7 @@ func TestWatcher_Shutdown_FlushesPendingRenames(t *testing.T) {
 	defer cancel()
 
 	go w.Run(ctx)
+	time.Sleep(50 * time.Millisecond) // let watcher goroutine enter event loop
 
 	// Create file so scanner knows about it
 	path := filepath.Join(root, "temp.md")

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -172,3 +172,131 @@ func TestWatcher_Shutdown_FlushesPendingRenames(t *testing.T) {
 	})
 	_ = ev
 }
+
+func TestWatcher_IgnorePaths_SuppressesRemove(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w, err := New(dir, nil, zerolog.Nop(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	go w.Run(ctx)
+
+	// Create a file first (before adding to ignore set)
+	filePath := filepath.Join(dir, "old.md")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain initial create event
+	select {
+	case <-w.Out:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial create event")
+	}
+
+	// Now add old path to ignored set
+	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+
+	// Now simulate a remove by the remote rename fixup
+	if err := os.Remove(filePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// The remove should be SUPPRESSED
+	select {
+	case ev := <-w.Out:
+		t.Fatalf("received unexpected event for suppressed path: %v", ev)
+	case <-time.After(500 * time.Millisecond):
+		// Expected: no event
+	}
+}
+
+func TestWatcher_IgnorePaths_SuppressesCreate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w, err := New(dir, nil, zerolog.Nop(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	go w.Run(ctx)
+
+	// Add new path to ignored set
+	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+
+	// Create file at new path (simulating remote rename creating new.md)
+	filePath := filepath.Join(dir, "new.md")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The create should be SUPPRESSED
+	select {
+	case ev := <-w.Out:
+		t.Fatalf("received unexpected event for suppressed path: %v", ev)
+	case <-time.After(2 * time.Second):
+		// Expected: no event
+	}
+}
+
+func TestWatcher_IgnorePaths_NotSuppressedWhenUnrelated(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w, err := New(dir, nil, zerolog.Nop(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	go w.Run(ctx)
+
+	// Add some paths to ignored set
+	w.AddIgnorePaths([]RenamePair{{OldPath: "ignored-old.md", NewPath: "ignored-new.md"}})
+
+	// Create an UNRELATED file
+	filePath := filepath.Join(dir, "normal.md")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The create should NOT be suppressed
+	select {
+	case ev := <-w.Out:
+		if ev.Type != EventCreate {
+			t.Fatalf("expected EventCreate, got %v", ev.Type)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for expected event")
+	}
+}
+
+func TestWatcher_IgnorePaths_FlushIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w, err := New(dir, nil, zerolog.Nop(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	go w.Run(ctx)
+
+	// Add path to ignored set, then flush
+	w.AddIgnorePaths([]RenamePair{{OldPath: "old.md", NewPath: "new.md"}})
+	w.FlushIgnored()
+
+	// Now create file at new path — should NOT be suppressed (flush cleared it)
+	filePath := filepath.Join(dir, "new.md")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case ev := <-w.Out:
+		if ev.Type != EventCreate {
+			t.Fatalf("expected EventCreate after flush, got %v", ev.Type)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for expected event after flush")
+	}
+}

--- a/src/internal/util/files.go
+++ b/src/internal/util/files.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Belphemur/obsidian-headless/src-go/internal/model"
+	"github.com/Belphemur/obsidian-headless/internal/model"
 	"github.com/djherbis/times"
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/scrypt"

--- a/website/src/architecture/sync-protocol.md
+++ b/website/src/architecture/sync-protocol.md
@@ -223,6 +223,39 @@ When any device pushes a change, the server broadcasts a push notification to **
 The server echoes push notifications back to the sender. The client must detect and ignore these self-echoes. A common approach is to compare the `device` and `mtime` fields with the most recently pushed file.
 :::
 
+### Rename Semantics
+
+::: info Renames are NOT communicated natively
+The Obsidian Sync server does not have a dedicated "rename" protocol message.
+:::
+
+When a file is renamed on another device, the server sends **two independent push notifications** that share the same UID:
+
+| Push | Path | `deleted` | Content |
+|------|------|-----------|---------|
+| 1 | New path (e.g., `new.md`) | `false` | Full file content |
+| 2 | Old path (e.g., `old.md`) | `true` | Empty |
+
+The client **detects remote renames** by correlating these two pushes via UID matching:
+
+1. Scans `currentRemote` for deleted entries with a known UID
+2. Finds active entries with the same UID
+3. If the UIDs match and the paths differ → it's a rename
+
+```mermaid
+flowchart TD
+    A[Server sends two pushes: delete old, create new] --> B{Client: same UID?}
+    B -->|Yes, different paths| C[Rename detected]
+    B -->|No| D[Treat as separate delete + download]
+    C --> E{Local file at old path modified?}
+    E -->|No| F[Rename local file in-place, no download]
+    E -->|Yes| G[Preserve local file, download new path as copy]
+```
+
+The rename detection runs before `buildPlan` in both `RunOnce` and continuous sync modes. When a rename is enacted locally, the filesystem watcher's `AddIgnorePaths` mechanism suppresses the resulting fsnotify events to prevent them from being misinterpreted as new user changes.
+
+See `src/internal/sync/rename.go` for the implementation.
+
 ### Pull
 
 #### Pull Request (Client → Server)

--- a/website/src/architecture/sync-protocol.md
+++ b/website/src/architecture/sync-protocol.md
@@ -236,11 +236,10 @@ When a file is renamed on another device, the server sends **two independent pus
 | 1 | New path (e.g., `new.md`) | `false` | Full file content |
 | 2 | Old path (e.g., `old.md`) | `true` | Empty |
 
-The client **detects remote renames** by correlating these two pushes via UID matching:
+The client **detects remote renames** by correlating these two pushes via UID matching in a single pass over `currentRemote`:
 
-1. Scans `currentRemote` for deleted entries with a known UID
-2. Finds active entries with the same UID
-3. If the UIDs match and the paths differ → it's a rename
+1. Collects deleted entries with a known UID and active entries with the same UID
+2. If the UIDs match and the paths differ → it's a rename
 
 ```mermaid
 flowchart TD
@@ -248,8 +247,10 @@ flowchart TD
     B -->|Yes, different paths| C[Rename detected]
     B -->|No| D[Treat as separate delete + download]
     C --> E{Local file at old path modified?}
-    E -->|No| F[Rename local file in-place, no download]
+    E -->|No| F[Create parent dirs, rename local file in-place, no download]
     E -->|Yes| G[Preserve local file, download new path as copy]
+    C --> H{No previous state for old path?}
+    H -->|Yes| G
 ```
 
 The rename detection runs before `buildPlan` in both `RunOnce` and continuous sync modes. When a rename is enacted locally, the filesystem watcher's `AddIgnorePaths` mechanism suppresses the resulting fsnotify events to prevent them from being misinterpreted as new user changes.

--- a/website/src/installation/from-source.md
+++ b/website/src/installation/from-source.md
@@ -7,7 +7,7 @@ title: From Source
 ## Go Install
 
 ```bash
-go install github.com/Belphemur/obsidian-headless/src/cmd/ob-go@latest
+go install github.com/Belphemur/obsidian-headless/cmd/ob-go@latest
 ln -sf "$(go env GOPATH)/bin/ob-go" "$(go env GOPATH)/bin/ob"
 ```
 

--- a/website/src/usage/sync.md
+++ b/website/src/usage/sync.md
@@ -116,3 +116,12 @@ ob sync [--path <path>] [--continuous]
 |------|---------|-------------|
 | `--path` | `.` | Local vault path |
 | `--continuous` | `false` | Run continuously (watch for changes) |
+
+### Remote rename handling
+
+When files are renamed on another device (e.g., via the Obsidian desktop app), the sync engine detects the rename automatically via UID matching:
+
+- **Unmodified local files** are renamed in-place — no re-download is needed.
+- **Modified local files** are preserved at their original path. The remote version is downloaded to the new path as a separate file, and the conflict is logged.
+
+This works in both one-shot (`ob sync`) and continuous (`ob sync --continuous`) modes without any configuration.


### PR DESCRIPTION
## Summary

Fixes #51 — three related sync bugs: remote rename detection, duplicate downloads, and file loss on rename.

## Root Causes

1. **Remote renames not detected**: When a file is renamed on the remote (Obsidian cloud), the server sends two independent WebSocket push messages (delete old + create new). The client stored both in `cs.remote` by path, and `buildPlan` produced `deleteLocal` for the old path + `download` for the new path — the rename chain was lost, and local modifications were discarded.

2. **Duplicate downloads**: `acquireLock()` used `os.Create()` which on Linux never fails for existing files (it just truncates). The `os.IsExist` check was dead code, meaning no exclusive locking existed. Two concurrent `doSync()` goroutines could both download the same files.

3. **Concurrent `doSync` race**: The `scheduleSync` debounce timer spawns a new goroutine per fire via `time.AfterFunc`. Without intra-process guarding, overlapping sync cycles could corrupt state.

## Changes

### Phase 1: Lock Fix (`fix(sync): use O_EXCL for exclusive lock file creation`)
- `src/internal/sync/lock.go`: Replaced `os.Create` → `os.OpenFile(...O_EXCL, 0600)` for genuine exclusive lock creation
- `src/internal/sync/lock_test.go`: 6 tests — all pass with `-race`

### Phase 2: Remote Rename Detection (`feat(sync): detect remote renames via UID-based correlation`)
- `src/internal/sync/rename.go`: `applyRemoteRenameFixups()` — UID-based correlation of deleted+active entries in `currentRemote`; renames local file on disk if unmodified; preserves locally modified files as conflicts
- `src/internal/sync/rename_test.go`: 8 tests covering basic rename, different UIDs, empty maps, local modified, folder exclusion, UID=0, same path, os.Rename failure
- `src/internal/sync/watch/event.go`: Added `RenamePair` struct
- `src/internal/sync/watch/watcher.go`: Added `ignoredOld`/`ignoredNew` maps, `AddIgnorePaths()`, `FlushIgnored()`, `isIgnored()` — suppresses fsnotify events for paths affected by remote renames
- `src/internal/sync/watch/watcher_test.go`: 4 tests for ignore suppression
- `src/internal/sync/continuous.go`: Integration — calls `FlushIgnored` at start of `doSync`, `applyRemoteRenameFixups` before `buildPlan`, `AddIgnorePaths` for enacted renames
- `src/internal/sync/engine.go`: Integration in `RunOnce` — calls `applyRemoteRenameFixups` before `buildPlan`

### Phase 3: Concurrent doSync Guard
- `src/internal/sync/continuous.go`: Added `syncInProgress atomic.Bool` to `continuousState`; fast-path check at `doSync` top skips overlapping goroutines

### Phase 4: Zerolog Timestamps (`fix(logging): set human-readable timestamp format on console writers`)
- `src/internal/logging/logger.go`: Set `TimeFormat: "15:04:05.000"` on `ConsoleWriter`

### Phase 5: Documentation (`docs: add remote rename detection documentation and commit frequency guideline`)
- `docs/architecture.md`: Added "Remote rename detection (UID-based)" subsection
- `docs/sync-protocol.md`: Added "Rename Semantics" section
- `website/src/architecture/sync-protocol.md`: Added "Rename Semantics" with VuePress callout + Mermaid diagram
- `website/src/usage/sync.md`: Added "Remote rename handling" section
- `AGENTS.md`: Added "Documentation" and "Commit Frequency" sections
- `.agents/sync-docs/SKILL.md`: Agent Skills specification

### Phase 6: Namespace Cleanup (`chore: drop src-go Go module namespace for clean import paths`)
- Dropped `/src` suffix from Go module path for cleaner imports
- Updated all 39+ files including `go.mod`, all `.go` files, docs, and website

## Verification

- ✅ `go build ./...` — PASS
- ✅ `go vet ./...` — PASS
- ✅ `go test -race -count=1 -shuffle=on ./...` — ALL PASS (~51s)
- ✅ 18 new tests, no regressions
- ✅ +390/-40 lines across 15 files