### PR TITLE
fix(sync): add hash-based fallback for remote rename detection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ single `"renamed"` event (with both old and new paths) instead of separate
 `"file-removed"` + `"file-created"` events. This lets the sync engine move the
 metadata record without re-hashing or re-uploading the unchanged content.
 
-### Remote rename detection (UID-based)
+### Remote rename detection (UID + hash-based fallback)
 
 When a file is renamed on another device, the Obsidian Sync server does not
 have a native "rename" protocol message. Instead it sends **two separate push
@@ -125,12 +125,25 @@ matching in `applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`):
   disk via `os.Rename` to `newPath`. The sync state metadata moves with it —
   `PreviousPath` is set to preserve the rename chain. No re-download is needed.
 - If the local file at `oldPath` was **modified** locally, or if there is no
-  previous state for `oldPath` in either `previousLocal` or `previousRemote`,
-  it is preserved at its original path and the conflict is logged. The remote
+  previous state for `oldPath` (missing from both `previousLocal` and
+  `previousRemote`), it is preserved at its original path and the conflict is
+  logged. The remote
   version at `newPath` is downloaded normally, and `buildPlan` handles the two
   files independently.
 - Rename or directory-creation failures are recorded as conflicts rather than
   returned as errors.
+
+When the Obsidian desktop app performs a rename, it sometimes executes a
+**delete + upload** as separate operations, causing the server to assign a
+**new UID** to the uploaded file. In these cases UID matching fails. The
+client falls back to **hash-based detection**: for deleted records that were
+not matched by UID, it compares file hashes between the deleted and active
+entries. If the deleted record's hash is empty, it falls back to
+`previousRemote[path].Hash`. When exactly one active entry shares the same
+hash, the rename is detected. If multiple candidates match (ambiguous hash),
+the fallback is skipped with a warning and the entries are treated as
+independent operations. This ensures pure renames — where content is unchanged
+— are detected even when UIDs differ.
 
 After renaming, the watcher is notified of the affected paths via
 `AddIgnorePaths()` so that the resulting filesystem events (from `os.Rename`)

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -210,8 +210,25 @@ Both pushes share the **same `uid`** value, corresponding to the file's
 identity on the server. The client detects the rename by correlating
 deleted and active entries in the push map that share the same UID.
 
-This client-side UID correlation is implemented in
-`applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`).
+In practice, UIDs may not always match. When the Obsidian desktop client
+performs a rename as separate delete and upload operations, the server can
+assign a **new UID** to the uploaded file. The headless client mitigates this
+with **hash-based fallback detection**: when UID matching fails, it compares
+file hashes between deleted and active entries. Because a pure rename leaves
+the file content unchanged, the hashes still match and the rename is detected.
+
+If the deleted record's hash is empty (some server push notifications omit it),
+the client falls back to `previousRemote[path].Hash` to recover the hash. When
+exactly one active entry shares the same hash, the rename is confirmed. If
+multiple candidates match (ambiguous hash), the fallback is skipped with a
+warning and the entries are treated as independent operations.
+
+This client-side UID correlation (with hash fallback) is implemented in
+`applyRemoteRenameFixups()` (see `src/internal/sync/rename.go`). It runs in
+both `RunOnce` and continuous sync modes, before `buildPlan` is called.
+After enacting a rename locally, the filesystem watcher's `AddIgnorePaths`
+mechanism suppresses the resulting fsnotify events to prevent them from being
+misinterpreted as new user changes.
 
 ### Ready Notification (Server → Client)
 

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -231,7 +231,11 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 						cs.mu.Lock()
 						cs.remote[record.Path] = record
 						cs.mu.Unlock()
-						e.Logger.Debug().Str("path", record.Path).Msg("continuous: received push")
+						e.Logger.Debug().
+							Str("path", record.Path).
+							Int64("uid", record.UID).
+							Bool("deleted", record.Deleted).
+							Msg("continuous: received push")
 					}
 
 					select {

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -38,6 +38,32 @@ func applyRemoteRenameFixups(
 ) *RemoteRenameResult {
 	result := &RemoteRenameResult{}
 
+	// Debug: log UIDs of all deleted and active records for diagnostics.
+	if logger.Debug().Enabled() {
+		for path, record := range currentRemote {
+			if record.Folder {
+				continue
+			}
+			logger.Debug().
+				Str("path", path).
+				Int64("uid", record.UID).
+				Bool("deleted", record.Deleted).
+				Msg("remote rename fixups: currentRemote record")
+		}
+	}
+
+	// Guard: nothing to do if there are no deleted records.
+	hasDeletedRecords := false
+	for _, record := range currentRemote {
+		if !record.Folder && record.Deleted {
+			hasDeletedRecords = true
+			break
+		}
+	}
+	if !hasDeletedRecords {
+		return result
+	}
+
 	// Step 1: In a single pass, collect deleted UIDs and active UID→newPath mappings.
 	deletedUIDs := make(map[int64]string)  // uid → oldPath
 	uidToNewPath := make(map[int64]string) // uid → newPath
@@ -52,10 +78,13 @@ func applyRemoteRenameFixups(
 		}
 	}
 
-	// Guard: nothing to correlate.
-	if len(deletedUIDs) == 0 {
-		return result
-	}
+	// processedPaths tracks deleted records that were examined by UID matching,
+	// so the hash fallback can skip them.
+	processedPaths := make(map[string]struct{})
+
+	// uidMatchedActivePaths tracks active paths that were targets of successful
+	// UID-based renames, preventing the hash fallback from reusing them.
+	uidMatchedActivePaths := make(map[string]struct{})
 
 	// Step 2: Correlate deleted UIDs with active UIDs to find renames.
 	for uid, oldPath := range deletedUIDs {
@@ -63,113 +92,196 @@ func applyRemoteRenameFixups(
 		if !ok || newPath == oldPath {
 			continue
 		}
+		processedPaths[oldPath] = struct{}{}
 
-		// Remote rename detected: oldPath → newPath
 		logger.Info().
 			Str("oldPath", oldPath).
 			Str("newPath", newPath).
 			Int64("uid", uid).
 			Msg("remote rename detected via UID match")
 
-		// Step 2a: Handle local file at oldPath
-		oldLocal, hasOldLocal := currentLocal[oldPath]
-		renameEnacted := false
-		if hasOldLocal {
-			localPath := filepath.Join(vaultPath, oldPath)
-			newLocalPath := filepath.Join(vaultPath, newPath)
+		enacted, conflict := handleRemoteRename(oldPath, newPath, currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, onBeforeRename)
+		if conflict != "" {
+			result.Conflicts = append(result.Conflicts, conflict)
+			continue
+		}
+		if enacted {
+			result.Enacted = append(result.Enacted, model.RenamePair{OldPath: oldPath, NewPath: newPath})
+		}
+		uidMatchedActivePaths[newPath] = struct{}{}
+	}
 
-			// Check if local file was modified
-			localModified := false
-			_, hasPrevLocal := previousLocal[oldPath]
-			if hasPrevLocal {
-				localModified = oldLocal.Hash != previousLocal[oldPath].Hash
-			}
+	// Step 3: Hash-based fallback for deleted records not matched by UID.
+	// Build a map of hash → active paths from the remaining active records.
+	hashToActivePaths := make(map[string][]string)
+	for path, record := range currentRemote {
+		if record.Folder || record.Deleted || record.Hash == "" {
+			continue
+		}
+		hashToActivePaths[record.Hash] = append(hashToActivePaths[record.Hash], path)
+	}
 
-			// If neither previousLocal nor previousRemote has oldPath, can't verify
-			// the local file corresponds to the remote file — treat as conflict.
-			if !hasPrevLocal {
-				if _, hasPrevRemote := previousRemote[oldPath]; !hasPrevRemote {
-					logger.Warn().
-						Str("oldPath", oldPath).
-						Msg("remote rename: no previous state for oldPath, preserving local file")
-					result.Conflicts = append(result.Conflicts, oldPath)
-					continue
-				}
-			}
+	for path, record := range currentRemote {
+		if record.Folder || !record.Deleted {
+			continue
+		}
+		if _, processed := processedPaths[path]; processed {
+			continue
+		}
 
-			if localModified {
-				// Local file was modified → preserve it, don't rename
-				logger.Warn().
-					Str("oldPath", oldPath).
-					Str("localHash", oldLocal.Hash).
-					Str("prevHash", previousLocal[oldPath].Hash).
-					Msg("remote rename: local file modified, preserving")
-				result.Conflicts = append(result.Conflicts, oldPath)
-			} else if _, exists := currentLocal[newPath]; exists {
-				// Destination already exists locally
-				logger.Warn().
-					Str("oldPath", oldPath).
-					Str("newPath", newPath).
-					Msg("remote rename: destination exists locally, preserving")
-				result.Conflicts = append(result.Conflicts, oldPath)
-			} else {
-			// Local file is unmodified and destination is clear → rename it on disk.
-			// Register the ignore pair before the filesystem rename to prevent
-			// the watcher from seeing our own rename as a user-initiated change.
-			pair := model.RenamePair{OldPath: oldPath, NewPath: newPath}
-			if onBeforeRename != nil {
-				onBeforeRename(pair)
-			}
-			if err := os.MkdirAll(filepath.Dir(newLocalPath), 0o755); err != nil {
-				logger.Error().
-					Err(err).
-					Str("newPath", newPath).
-					Msg("remote rename: os.MkdirAll failed, treating as conflict")
-				result.Conflicts = append(result.Conflicts, oldPath)
-			} else if err := os.Rename(localPath, newLocalPath); err != nil {
-				logger.Error().
-					Err(err).
-					Str("oldPath", oldPath).
-					Str("newPath", newPath).
-					Msg("remote rename: os.Rename failed, treating as conflict")
-				result.Conflicts = append(result.Conflicts, oldPath)
-			} else {
-				// Rename succeeded on disk
-				oldLocal.Path = newPath
-				currentLocal[newPath] = oldLocal
-				delete(currentLocal, oldPath)
-
-				result.Enacted = append(result.Enacted, pair)
-				renameEnacted = true
-				logger.Info().
-					Str("oldPath", oldPath).
-					Str("newPath", newPath).
-					Msg("remote rename: local file renamed on disk")
-			}
+		deletedHash := record.Hash
+		if deletedHash == "" {
+			if prev, ok := previousRemote[path]; ok {
+				deletedHash = prev.Hash
 			}
 		}
-		// else: local file already absent → nothing to rename on disk
-
-		// Step 2b: Update metadata state — only if the rename was enacted on disk
-		// or the local file was already absent (rename happened on another device).
-		if renameEnacted || !hasOldLocal {
-			// Update previousRemote to reflect the rename
-			if oldRemote, exists := previousRemote[oldPath]; exists {
-				oldRemote.PreviousPath = oldPath
-				oldRemote.Path = newPath
-				previousRemote[newPath] = oldRemote
-				delete(previousRemote, oldPath)
-			}
-
-			// Remove the deleted entry from currentRemote so buildPlan
-			// doesn't emit a deleteLocal action for oldPath.
-			delete(currentRemote, oldPath)
+		if deletedHash == "" {
+			continue
 		}
-		// If !renameEnacted && hasOldLocal: local file exists but rename was
-		// blocked (modified, dest exists, or rename failed). Don't mutate
-		// previousRemote or currentRemote — let buildPlan handle both paths
-		// independently.
+
+		activePaths, ok := hashToActivePaths[deletedHash]
+		if !ok {
+			continue
+		}
+
+		var candidates []string
+		for _, activePath := range activePaths {
+			if activePath == path {
+				continue
+			}
+			if _, consumed := uidMatchedActivePaths[activePath]; consumed {
+				continue
+			}
+			candidates = append(candidates, activePath)
+		}
+
+		if len(candidates) == 0 {
+			continue
+		}
+		if len(candidates) > 1 {
+			logger.Warn().
+				Str("oldPath", path).
+				Str("hash", deletedHash).
+				Int("matchCount", len(candidates)).
+				Msg("remote rename: ambiguous hash match, skipping")
+			continue
+		}
+
+		newPath := candidates[0]
+
+		logger.Info().
+			Str("oldPath", path).
+			Str("newPath", newPath).
+			Str("hash", deletedHash).
+			Msg("remote rename detected via hash match")
+
+		enacted, conflict := handleRemoteRename(path, newPath, currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, onBeforeRename)
+		if conflict != "" {
+			result.Conflicts = append(result.Conflicts, conflict)
+			continue
+		}
+		if enacted {
+			result.Enacted = append(result.Enacted, model.RenamePair{OldPath: path, NewPath: newPath})
+		}
+		uidMatchedActivePaths[newPath] = struct{}{}
 	}
 
 	return result
+}
+
+// handleRemoteRename performs the local filesystem rename and metadata updates
+// for a detected remote rename from oldPath to newPath.
+// Returns true if the local file was renamed on disk, and a non-empty conflict
+// path if the rename was blocked (local modified, destination exists, etc.).
+func handleRemoteRename(
+	oldPath, newPath string,
+	currentRemote map[string]model.FileRecord,
+	previousRemote map[string]model.FileRecord,
+	previousLocal map[string]model.FileRecord,
+	currentLocal map[string]model.FileRecord,
+	vaultPath string,
+	logger zerolog.Logger,
+	onBeforeRename func(model.RenamePair),
+) (enacted bool, conflict string) {
+	oldLocal, hasOldLocal := currentLocal[oldPath]
+	renameEnacted := false
+	if hasOldLocal {
+		localPath := filepath.Join(vaultPath, oldPath)
+		newLocalPath := filepath.Join(vaultPath, newPath)
+
+		localModified := false
+		_, hasPrevLocal := previousLocal[oldPath]
+		if hasPrevLocal {
+			localModified = oldLocal.Hash != previousLocal[oldPath].Hash
+		}
+
+		if !hasPrevLocal {
+			if _, hasPrevRemote := previousRemote[oldPath]; !hasPrevRemote {
+				logger.Warn().
+					Str("oldPath", oldPath).
+					Msg("remote rename: no previous state for oldPath, preserving local file")
+				return false, oldPath
+			}
+		}
+
+		if localModified {
+			logger.Warn().
+				Str("oldPath", oldPath).
+				Str("localHash", oldLocal.Hash).
+				Str("prevHash", previousLocal[oldPath].Hash).
+				Msg("remote rename: local file modified, preserving")
+			return false, oldPath
+		}
+
+		if _, exists := currentLocal[newPath]; exists {
+			logger.Warn().
+				Str("oldPath", oldPath).
+				Str("newPath", newPath).
+				Msg("remote rename: destination exists locally, preserving")
+			return false, oldPath
+		}
+
+		pair := model.RenamePair{OldPath: oldPath, NewPath: newPath}
+		if onBeforeRename != nil {
+			onBeforeRename(pair)
+		}
+		if err := os.MkdirAll(filepath.Dir(newLocalPath), 0o755); err != nil {
+			logger.Error().
+				Err(err).
+				Str("newPath", newPath).
+				Msg("remote rename: os.MkdirAll failed, treating as conflict")
+			return false, oldPath
+		}
+		if err := os.Rename(localPath, newLocalPath); err != nil {
+			logger.Error().
+				Err(err).
+				Str("oldPath", oldPath).
+				Str("newPath", newPath).
+				Msg("remote rename: os.Rename failed, treating as conflict")
+			return false, oldPath
+		}
+
+		oldLocal.Path = newPath
+		currentLocal[newPath] = oldLocal
+		delete(currentLocal, oldPath)
+
+		renameEnacted = true
+		logger.Info().
+			Str("oldPath", oldPath).
+			Str("newPath", newPath).
+			Msg("remote rename: local file renamed on disk")
+	}
+
+	if renameEnacted || !hasOldLocal {
+		if oldRemote, exists := previousRemote[oldPath]; exists {
+			oldRemote.PreviousPath = oldPath
+			oldRemote.Path = newPath
+			previousRemote[newPath] = oldRemote
+			delete(previousRemote, oldPath)
+		}
+
+		delete(currentRemote, oldPath)
+	}
+
+	return renameEnacted, ""
 }

--- a/src/internal/sync/rename.go
+++ b/src/internal/sync/rename.go
@@ -64,11 +64,19 @@ func applyRemoteRenameFixups(
 		return result
 	}
 
-	// Step 1: In a single pass, collect deleted UIDs and active UID→newPath mappings.
+	// Step 1: In a single pass, collect deleted UIDs, active UID→newPath
+	// mappings, and a list of deleted paths for the hash fallback.
 	deletedUIDs := make(map[int64]string)  // uid → oldPath
 	uidToNewPath := make(map[int64]string) // uid → newPath
+	var deletedPaths []string
 	for path, record := range currentRemote {
-		if record.Folder || record.UID == 0 {
+		if record.Folder {
+			continue
+		}
+		if record.Deleted {
+			deletedPaths = append(deletedPaths, path)
+		}
+		if record.UID == 0 {
 			continue
 		}
 		if record.Deleted {
@@ -82,8 +90,8 @@ func applyRemoteRenameFixups(
 	// so the hash fallback can skip them.
 	processedPaths := make(map[string]struct{})
 
-	// uidMatchedActivePaths tracks active paths that were targets of successful
-	// UID-based renames, preventing the hash fallback from reusing them.
+	// uidMatchedActivePaths tracks active paths that were targeted by
+	// UID-based or hash-based renames, preventing them from being reused.
 	uidMatchedActivePaths := make(map[string]struct{})
 
 	// Step 2: Correlate deleted UIDs with active UIDs to find renames.
@@ -100,6 +108,7 @@ func applyRemoteRenameFixups(
 			Int64("uid", uid).
 			Msg("remote rename detected via UID match")
 
+		uidMatchedActivePaths[newPath] = struct{}{}
 		enacted, conflict := handleRemoteRename(oldPath, newPath, currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, onBeforeRename)
 		if conflict != "" {
 			result.Conflicts = append(result.Conflicts, conflict)
@@ -108,7 +117,6 @@ func applyRemoteRenameFixups(
 		if enacted {
 			result.Enacted = append(result.Enacted, model.RenamePair{OldPath: oldPath, NewPath: newPath})
 		}
-		uidMatchedActivePaths[newPath] = struct{}{}
 	}
 
 	// Step 3: Hash-based fallback for deleted records not matched by UID.
@@ -121,13 +129,11 @@ func applyRemoteRenameFixups(
 		hashToActivePaths[record.Hash] = append(hashToActivePaths[record.Hash], path)
 	}
 
-	for path, record := range currentRemote {
-		if record.Folder || !record.Deleted {
-			continue
-		}
+	for _, path := range deletedPaths {
 		if _, processed := processedPaths[path]; processed {
 			continue
 		}
+		record := currentRemote[path]
 
 		deletedHash := record.Hash
 		if deletedHash == "" {
@@ -175,6 +181,7 @@ func applyRemoteRenameFixups(
 			Str("hash", deletedHash).
 			Msg("remote rename detected via hash match")
 
+		uidMatchedActivePaths[newPath] = struct{}{}
 		enacted, conflict := handleRemoteRename(path, newPath, currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, onBeforeRename)
 		if conflict != "" {
 			result.Conflicts = append(result.Conflicts, conflict)
@@ -183,7 +190,6 @@ func applyRemoteRenameFixups(
 		if enacted {
 			result.Enacted = append(result.Enacted, model.RenamePair{OldPath: path, NewPath: newPath})
 		}
-		uidMatchedActivePaths[newPath] = struct{}{}
 	}
 
 	return result
@@ -278,6 +284,16 @@ func handleRemoteRename(
 			oldRemote.Path = newPath
 			previousRemote[newPath] = oldRemote
 			delete(previousRemote, oldPath)
+		}
+
+		// When the server assigned a new UID (hash-fallback renames),
+		// sync it into previousRemote so three-way merges can pull
+		// base content by the correct UID.
+		if newRecord, ok := currentRemote[newPath]; ok && newRecord.UID != 0 {
+			if prev, ok := previousRemote[newPath]; ok && prev.UID != newRecord.UID {
+				prev.UID = newRecord.UID
+				previousRemote[newPath] = prev
+			}
 		}
 
 		delete(currentRemote, oldPath)

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -381,3 +381,268 @@ func TestApplyRemoteRenameFixups_RenameError(t *testing.T) {
 		t.Error("old.md should remain in currentRemote after rename failure")
 	}
 }
+
+func TestApplyRemoteRenameFixups_DifferentUIDsSameHash(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Different UIDs but same hash → should detect as rename via hash fallback.
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: 99, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	if err := os.WriteFile(localOldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 1 {
+		t.Fatalf("expected 1 enacted rename, got %d", len(result.Enacted))
+	}
+	if result.Enacted[0].OldPath != "old.md" || result.Enacted[0].NewPath != "new.md" {
+		t.Fatalf("unexpected rename pair: %+v", result.Enacted[0])
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+	if _, exists := currentRemote["old.md"]; exists {
+		t.Error("old.md should have been removed from currentRemote")
+	}
+	if _, exists := currentLocal["old.md"]; exists {
+		t.Error("old.md should have been removed from currentLocal")
+	}
+	if _, exists := currentLocal["new.md"]; !exists {
+		t.Error("new.md should be in currentLocal")
+	}
+	if _, err := os.Stat(filepath.Join(vaultPath, "old.md")); !os.IsNotExist(err) {
+		t.Error("old.md should not exist on disk after rename")
+	}
+	if _, err := os.Stat(filepath.Join(vaultPath, "new.md")); err != nil {
+		t.Error("new.md should exist on disk after rename")
+	}
+}
+
+func TestApplyRemoteRenameFixups_UIDZeroSameHash(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Deleted record with UID=0 (server omitted uid), same hash → should detect via hash fallback.
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: 99, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: 0, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 0},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 0},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+
+	localOldPath := filepath.Join(vaultPath, "old.md")
+	if err := os.WriteFile(localOldPath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 1 {
+		t.Fatalf("expected 1 enacted rename, got %d", len(result.Enacted))
+	}
+	if result.Enacted[0].OldPath != "old.md" || result.Enacted[0].NewPath != "new.md" {
+		t.Fatalf("unexpected rename pair: %+v", result.Enacted[0])
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+	if _, exists := currentRemote["old.md"]; exists {
+		t.Error("old.md should have been removed from currentRemote")
+	}
+}
+
+func TestApplyRemoteRenameFixups_DifferentUIDsDifferentHashes(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Different UIDs and different hashes → should NOT detect as rename.
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "def", UID: 99, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc", UID: 42},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old.md": {Path: "old.md", Hash: "abc"},
+	}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames, got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+	if _, exists := currentRemote["old.md"]; !exists {
+		t.Error("old.md should still be in currentRemote (different hashes, not a rename)")
+	}
+}
+
+func TestApplyRemoteRenameFixups_MultipleHashMatches(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Multiple renames with matching hashes → should detect all.
+	currentRemote := map[string]model.FileRecord{
+		"new1.md": {Path: "new1.md", Hash: "abc", UID: 101, Deleted: false},
+		"old1.md": {Path: "old1.md", Hash: "abc", UID: 1, Deleted: true},
+		"new2.md": {Path: "new2.md", Hash: "def", UID: 102, Deleted: false},
+		"old2.md": {Path: "old2.md", Hash: "def", UID: 2, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old1.md": {Path: "old1.md", Hash: "abc", UID: 1},
+		"old2.md": {Path: "old2.md", Hash: "def", UID: 2},
+	}
+	previousLocal := map[string]model.FileRecord{
+		"old1.md": {Path: "old1.md", Hash: "abc", UID: 1},
+		"old2.md": {Path: "old2.md", Hash: "def", UID: 2},
+	}
+	currentLocal := map[string]model.FileRecord{
+		"old1.md": {Path: "old1.md", Hash: "abc"},
+		"old2.md": {Path: "old2.md", Hash: "def"},
+	}
+
+	if err := os.WriteFile(filepath.Join(vaultPath, "old1.md"), []byte("hello1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vaultPath, "old2.md"), []byte("hello2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 2 {
+		t.Fatalf("expected 2 enacted renames, got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+
+	enactedPaths := make(map[string]string)
+	for _, pair := range result.Enacted {
+		enactedPaths[pair.OldPath] = pair.NewPath
+	}
+	if enactedPaths["old1.md"] != "new1.md" {
+		t.Errorf("expected old1.md -> new1.md, got %s", enactedPaths["old1.md"])
+	}
+	if enactedPaths["old2.md"] != "new2.md" {
+		t.Errorf("expected old2.md -> new2.md, got %s", enactedPaths["old2.md"])
+	}
+
+	if _, exists := currentRemote["old1.md"]; exists {
+		t.Error("old1.md should have been removed from currentRemote")
+	}
+	if _, exists := currentRemote["old2.md"]; exists {
+		t.Error("old2.md should have been removed from currentRemote")
+	}
+	if _, exists := currentLocal["new1.md"]; !exists {
+		t.Error("new1.md should be in currentLocal")
+	}
+	if _, exists := currentLocal["new2.md"]; !exists {
+		t.Error("new2.md should be in currentLocal")
+	}
+}
+
+func TestApplyRemoteRenameFixups_AmbiguousHashMatch(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Two DIFFERENT deleted files both have hash "shared",
+	// two DIFFERENT new files both have hash "shared".
+	// This creates an ambiguous hash match → skip.
+	currentRemote := map[string]model.FileRecord{
+		"new1.md": {Path: "new1.md", Hash: "shared", UID: 101, Deleted: false},
+		"new2.md": {Path: "new2.md", Hash: "shared", UID: 102, Deleted: false},
+		"old1.md": {Path: "old1.md", Hash: "shared", UID: 1, Deleted: true},
+		"old2.md": {Path: "old2.md", Hash: "shared", UID: 2, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{
+		"old1.md": {Path: "old1.md", Hash: "shared", UID: 1},
+		"old2.md": {Path: "old2.md", Hash: "shared", UID: 2},
+	}
+	previousLocal := map[string]model.FileRecord{}
+	currentLocal := map[string]model.FileRecord{}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (ambiguous hash match), got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+	// Both old entries should remain in currentRemote (not deleted, since renaming was skipped)
+	if _, exists := currentRemote["old1.md"]; !exists {
+		t.Error("old1.md should still be in currentRemote (ambiguous match, skipped)")
+	}
+	if _, exists := currentRemote["old2.md"]; !exists {
+		t.Error("old2.md should still be in currentRemote (ambiguous match, skipped)")
+	}
+}
+
+func TestApplyRemoteRenameFixups_EmptyHashNoFallback(t *testing.T) {
+	t.Parallel()
+	vaultPath, cleanup := setupRenameTest(t)
+	defer cleanup()
+
+	// Deleted record has empty hash and no previousRemote fallback available.
+	currentRemote := map[string]model.FileRecord{
+		"new.md": {Path: "new.md", Hash: "abc", UID: 99, Deleted: false},
+		"old.md": {Path: "old.md", Hash: "", UID: 42, Deleted: true},
+	}
+	previousRemote := map[string]model.FileRecord{}
+	previousLocal := map[string]model.FileRecord{}
+	currentLocal := map[string]model.FileRecord{}
+
+	logger := zerolog.Nop()
+	result := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, vaultPath, logger, nil)
+
+	if len(result.Enacted) != 0 {
+		t.Fatalf("expected 0 enacted renames (empty hash, no fallback), got %d", len(result.Enacted))
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d", len(result.Conflicts))
+	}
+	// old.md should remain in currentRemote
+	if _, exists := currentRemote["old.md"]; !exists {
+		t.Error("old.md should still be in currentRemote (empty hash, no fallback)")
+	}
+}

--- a/src/internal/sync/rename_test.go
+++ b/src/internal/sync/rename_test.go
@@ -434,6 +434,24 @@ func TestApplyRemoteRenameFixups_DifferentUIDsSameHash(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(vaultPath, "new.md")); err != nil {
 		t.Error("new.md should exist on disk after rename")
 	}
+
+	// Verify previousRemote state: new.md should exist with updated metadata
+	if prev, ok := previousRemote["new.md"]; !ok {
+		t.Error("previousRemote should have new.md after rename")
+	} else {
+		if prev.Path != "new.md" {
+			t.Errorf("previousRemote new.md path = %s, want new.md", prev.Path)
+		}
+		if prev.PreviousPath != "old.md" {
+			t.Errorf("previousRemote new.md PreviousPath = %s, want old.md", prev.PreviousPath)
+		}
+		if prev.UID != 99 {
+			t.Errorf("previousRemote new.md UID = %d, want 99 (server-assigned)", prev.UID)
+		}
+	}
+	if _, ok := previousRemote["old.md"]; ok {
+		t.Error("previousRemote should not have old.md after rename")
+	}
 }
 
 func TestApplyRemoteRenameFixups_UIDZeroSameHash(t *testing.T) {
@@ -475,6 +493,24 @@ func TestApplyRemoteRenameFixups_UIDZeroSameHash(t *testing.T) {
 	}
 	if _, exists := currentRemote["old.md"]; exists {
 		t.Error("old.md should have been removed from currentRemote")
+	}
+
+	// Verify previousRemote state: new.md should exist with UID from currentRemote
+	if prev, ok := previousRemote["new.md"]; !ok {
+		t.Error("previousRemote should have new.md after rename")
+	} else {
+		if prev.Path != "new.md" {
+			t.Errorf("previousRemote new.md path = %s, want new.md", prev.Path)
+		}
+		if prev.PreviousPath != "old.md" {
+			t.Errorf("previousRemote new.md PreviousPath = %s, want old.md", prev.PreviousPath)
+		}
+		if prev.UID != 99 {
+			t.Errorf("previousRemote new.md UID = %d, want 99 (from currentRemote)", prev.UID)
+		}
+	}
+	if _, ok := previousRemote["old.md"]; ok {
+		t.Error("previousRemote should not have old.md after rename")
 	}
 }
 

--- a/website/src/architecture/sync-protocol.md
+++ b/website/src/architecture/sync-protocol.md
@@ -229,28 +229,30 @@ The server echoes push notifications back to the sender. The client must detect 
 The Obsidian Sync server does not have a dedicated "rename" protocol message.
 :::
 
-When a file is renamed on another device, the server sends **two independent push notifications** that share the same UID:
+When a file is renamed on another device, the server sends **two independent push notifications**. In the ideal case they share the same UID:
 
 | Push | Path | `deleted` | Content |
 |------|------|-----------|---------|
 | 1 | New path (e.g., `new.md`) | `false` | Full file content |
 | 2 | Old path (e.g., `old.md`) | `true` | Empty |
 
-The client **detects remote renames** by correlating these two pushes via UID matching in a single pass over `currentRemote`:
+In practice, UIDs may differ. When the Obsidian desktop client performs a rename as separate delete and upload operations, the server assigns a **new UID** to the uploaded file. The client handles this with a two-step detection in `applyRemoteRenameFixups()`:
 
-1. Collects deleted entries with a known UID and active entries with the same UID
-2. If the UIDs match and the paths differ → it's a rename
+1. **UID matching**: collect deleted and active entries with the same UID. If the UIDs match and the paths differ → it's a rename.
+2. **Hash-based fallback**: for deleted entries not matched by UID, compare file hashes between deleted and active entries. If the deleted record's hash is empty, it falls back to `previousRemote[path].Hash`. When exactly one active entry shares the same hash, the rename is detected. Ambiguous matches (multiple candidates with the same hash) are skipped with a warning.
 
 ```mermaid
 flowchart TD
     A[Server sends two pushes: delete old, create new] --> B{Client: same UID?}
     B -->|Yes, different paths| C[Rename detected]
-    B -->|No| D[Treat as separate delete + download]
-    C --> E{Local file at old path modified?}
+    B -->|No| H{Same hash?}
+    H -->|Yes, unambiguous| C
+    H -->|No or ambiguous| D[Treat as separate delete + download]
+    C --> I{No previous state for old path?}
+    I -->|Yes| G[Preserve local file, download new path as copy]
+    I -->|No| E{Local file at old path modified?}
+    E -->|Yes| G
     E -->|No| F[Create parent dirs, rename local file in-place, no download]
-    E -->|Yes| G[Preserve local file, download new path as copy]
-    C --> H{No previous state for old path?}
-    H -->|Yes| G
 ```
 
 The rename detection runs before `buildPlan` in both `RunOnce` and continuous sync modes. When a rename is enacted locally, the filesystem watcher's `AddIgnorePaths` mechanism suppresses the resulting fsnotify events to prevent them from being misinterpreted as new user changes.


### PR DESCRIPTION
## Problem

When a file is renamed on another Obsidian device, the headless client treats it as **deleteLocal + download** instead of a **rename**. This causes unnecessary file deletion and re-download.

### Root Cause

The Obsidian desktop app performs a remote rename as **delete old + upload new**. The server assigns a **new UID** to the uploaded file, so the existing UID-only rename detection in `applyRemoteRenameFixups` fails.

## Solution

Add **hash-based fallback rename detection** (Step 3) that runs after UID matching:

- Compare hashes between deleted and active records in `currentRemote`
- Fall back to `previousRemote` hash when the deleted record's hash is empty
- Skip ambiguous matches (multiple candidates with same hash) with a warning
- Extract shared `handleRemoteRename` helper used by both UID and hash paths

Pure renames (no content change) leave the file hash unchanged, enabling reliable detection even when UIDs differ.

## Changes

### `src/internal/sync/rename.go`
- Added hash-based fallback (Step 3) after UID matching
- Extracted `handleRemoteRename` helper
- Added debug logging for UIDs (guarded by `logger.Debug().Enabled()`)
- `processedPaths` and `uidMatchedActivePaths` tracking prevents double-processing

### `src/internal/sync/continuous.go`
- Enhanced push message debug log with `uid` and `deleted` fields

### `src/internal/sync/rename_test.go`
6 new tests (15 total):
- Different UIDs, same hash → rename detected
- UID=0, same hash via `previousRemote` → rename detected
- Different UIDs, different hashes → no rename
- Multiple hash-matched pairs → all detected
- Ambiguous hash collision → skipped
- Empty hash, no fallback → skipped

### Documentation
Updated `docs/architecture.md`, `docs/sync-protocol.md`, and `website/src/architecture/sync-protocol.md` to reflect the two-step UID + hash-based fallback detection.

## Test Results

- All 15 `TestApplyRemoteRenameFixups_*` tests: **PASS**
- Full sync test suite (39/39): **PASS**
- Race detector: **clean**
- Lint, vet, build: all **PASS**