### PR TITLE
fix(sync): send relatedpath on local file renames

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,6 +152,40 @@ are suppressed and not misinterpreted as user-initiated renames.
 This detection runs in both `RunOnce` and continuous sync modes, before
 `buildPlan` is called.
 
+### Local rename propagation to remote
+
+When a local file rename is detected by the filesystem watcher, the rename
+source path must be communicated to the server via the `relatedpath` field
+in the WebSocket push message. This propagation flows through three stages:
+
+1. **Watcher detection** — The `FileSystemAdapter` detects renames via
+   inode tracking (Linux/macOS) and emits a `ScanEvent` with both old and
+   new paths.
+
+2. **`applyRenameFixups()`** (`continuous.go`) — Runs before plan
+   construction. It moves the renamed file's record from its old path to its
+   new path in `previousLocal` and sets `PreviousPath` to preserve the
+   rename chain. This ensures that when `scanLocal()` later creates a fresh
+   `FileRecord` for the new path (without `PreviousPath`), the pipeline can
+   recover the rename source from the previous state.
+
+3. **`executePlan()`** (`engine.go`) — Accepts `previousLocal` as an
+   additional parameter (alongside the standard `currentLocal`,
+   `previousRemote` maps). In the `syncActionUpload` case, it enriches
+   the upload record with `PreviousPath` from the previous local state
+   before calling `session.push()`. After a successful push,
+   `PreviousPath` is cleared on the record in `currentLocal` to prevent
+   re-sending `relatedpath` on subsequent sync cycles.
+
+4. **`session.push()`** (`session.go`) — When `record.PreviousPath` is
+   non-empty, it encrypts the value via `s.encryptPath()` and includes it
+   as `relatedpath` in the WebSocket push message.
+
+The `previousLocal` map is loaded once per sync cycle from the state store
+and reused across plan building and execution. Each new cycle reloads it
+fresh, so clearing `PreviousPath` in `currentLocal` after push is sufficient
+to prevent retransmission.
+
 ### Watch disabled for read-only modes
 
 In `pull-only` and `mirror-remote` sync modes, local file changes are never

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -198,6 +198,23 @@ client must detect and ignore these self-echoes to avoid infinite sync loops.
 A common approach is to compare the `device` and `mtime` fields with the most
 recently pushed file.
 
+### Local Rename Signaling (Client → Server)
+
+When a file is renamed locally (`old.md` → `new.md`), the client sends two
+independent push notifications to the server:
+
+1. A push for the **old path** with `deleted: true`
+2. A push for the **new path** with `deleted: false` and `relatedpath` set to
+   the encrypted old path
+
+The `relatedpath` field in the UPLOAD push enables the server to recognize
+this as a rename rather than a separate delete-and-create operation. This
+allows the server to preserve version history and update internal links
+accordingly.
+
+The rename source path is encrypted using the same per-segment encryption
+scheme as the `path` field (V0: AES-GCM; V2/V3: AES-SIV).
+
 ### Rename Semantics
 
 The server does **not** communicate renames natively. When a file is renamed

--- a/legacy/src/sync/engine.ts
+++ b/legacy/src/sync/engine.ts
@@ -1229,7 +1229,7 @@ export class SyncEngine {
         // Push to server
         await server.push(
           filePath,
-          null,
+          record.previouspath || null,
           record.folder,
           false, // not deleted
           record.ctime,
@@ -1249,6 +1249,9 @@ export class SyncEngine {
         };
         this.serverFiles[filePath] = serverRecord;
         this.stateStore.setServerFileRecord(serverRecord);
+
+        // Clear previouspath after successful push (rename already communicated)
+        delete record.previouspath;
 
         this.log(`[sync] uploaded: ${filePath} (${formatBytes(record.size)})`);
       } catch (err) {

--- a/legacy/src/sync/engine.ts
+++ b/legacy/src/sync/engine.ts
@@ -1229,7 +1229,7 @@ export class SyncEngine {
         // Push to server
         await server.push(
           filePath,
-          record.previouspath || null,
+          null,
           record.folder,
           false, // not deleted
           record.ctime,
@@ -1249,9 +1249,6 @@ export class SyncEngine {
         };
         this.serverFiles[filePath] = serverRecord;
         this.stateStore.setServerFileRecord(serverRecord);
-
-        // Clear previouspath after successful push (rename already communicated)
-        delete record.previouspath;
 
         this.log(`[sync] uploaded: ${filePath} (${formatBytes(record.size)})`);
       } catch (err) {

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,29 +34,41 @@ const (
 // file renames detected by the watcher. Without this, a rename from oldPath→newPath
 // would appear as a delete of oldPath + create of newPath in buildPlan.
 // The record's PreviousPath field is set to preserve the rename chain.
-func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent, logger zerolog.Logger) {
+func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent, vaultPath string, logger zerolog.Logger) {
 	for _, ev := range renames {
 		if ev.Type != watchpkg.EventRename {
 			continue
 		}
-		if oldLocal, ok := previousLocal[ev.OldPath]; ok {
-			oldLocal.PreviousPath = ev.OldPath
-			oldLocal.Path = ev.Path
-			previousLocal[ev.Path] = oldLocal
-			delete(previousLocal, ev.OldPath)
+		// Convert absolute watcher paths to vault-relative
+		relOldPath, err := filepath.Rel(vaultPath, ev.OldPath)
+		if err != nil {
+			continue
+		}
+		relNewPath, err := filepath.Rel(vaultPath, ev.Path)
+		if err != nil {
+			continue
+		}
+		relOldPath = filepath.ToSlash(relOldPath)
+		relNewPath = filepath.ToSlash(relNewPath)
+
+		if oldLocal, ok := previousLocal[relOldPath]; ok {
+			oldLocal.PreviousPath = relOldPath
+			oldLocal.Path = relNewPath
+			previousLocal[relNewPath] = oldLocal
+			delete(previousLocal, relOldPath)
 			logger.Info().
-				Str("oldPath", ev.OldPath).
-				Str("newPath", ev.Path).
+				Str("oldPath", relOldPath).
+				Str("newPath", relNewPath).
 				Msg("continuous: local rename applied")
 		}
-		if oldRemote, ok := previousRemote[ev.OldPath]; ok {
-			oldRemote.PreviousPath = ev.OldPath
-			oldRemote.Path = ev.Path
-			previousRemote[ev.Path] = oldRemote
-			delete(previousRemote, ev.OldPath)
+		if oldRemote, ok := previousRemote[relOldPath]; ok {
+			oldRemote.PreviousPath = relOldPath
+			oldRemote.Path = relNewPath
+			previousRemote[relNewPath] = oldRemote
+			delete(previousRemote, relOldPath)
 			logger.Info().
-				Str("oldPath", ev.OldPath).
-				Str("newPath", ev.Path).
+				Str("oldPath", relOldPath).
+				Str("newPath", relNewPath).
 				Msg("continuous: remote rename applied")
 		}
 	}
@@ -374,7 +387,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		pendingRenames = pendingRenames[:0]
 		renamesMu.Unlock()
 
-		applyRenameFixups(previousLocal, previousRemote, snapshot, e.Logger)
+		applyRenameFixups(previousLocal, previousRemote, snapshot, e.Config.VaultPath, e.Logger)
 
 		// Flush stale ignorations from the previous sync cycle
 		watcher.FlushIgnored()

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -458,7 +458,7 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		session := newRemoteSession(connB, currentRemote, execVersion, ctx, e.enc, e.Logger, e.rawKey)
-		if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+		if err := e.executePlan(ctx, plan, currentLocal, previousRemote, previousLocal, session); err != nil {
 			e.Logger.Error().Err(err).Msg("continuous: failed to execute plan")
 			return
 		}

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -517,8 +517,11 @@ func TestContinuousHeartbeatAfterReconnect(t *testing.T) {
 
 func TestApplyRenameFixups(t *testing.T) {
 	t.Parallel()
+	vaultPath := "/tmp/vault"
 	oldPath := "old/file.md"
 	newPath := "new/file.md"
+	absOldPath := filepath.Join(vaultPath, oldPath)
+	absNewPath := filepath.Join(vaultPath, newPath)
 
 	t.Run("local rename fixup", func(t *testing.T) {
 		t.Parallel()
@@ -528,9 +531,9 @@ func TestApplyRenameFixups(t *testing.T) {
 		remote := map[string]model.FileRecord{}
 
 		renames := []watchpkg.ScanEvent{
-			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, zerolog.Nop())
+		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
 
 		// Old path should be gone
 		if _, ok := local[oldPath]; ok {
@@ -560,9 +563,9 @@ func TestApplyRenameFixups(t *testing.T) {
 		}
 
 		renames := []watchpkg.ScanEvent{
-			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, zerolog.Nop())
+		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
 
 		rec, ok := remote[newPath]
 		if !ok {
@@ -582,9 +585,9 @@ func TestApplyRenameFixups(t *testing.T) {
 		remote := map[string]model.FileRecord{}
 
 		renames := []watchpkg.ScanEvent{
-			{Path: newPath, OldPath: "nonexistent.md", Type: watchpkg.EventRename},
+			{Path: absNewPath, OldPath: filepath.Join(vaultPath, "nonexistent.md"), Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, zerolog.Nop())
+		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
 
 		// Should not panic, no records added
 		if len(local) != 0 || len(remote) != 0 {
@@ -600,10 +603,10 @@ func TestApplyRenameFixups(t *testing.T) {
 		remote := map[string]model.FileRecord{}
 
 		renames := []watchpkg.ScanEvent{
-			{Path: oldPath, Type: watchpkg.EventRemove},
-			{Path: newPath, OldPath: oldPath, Type: watchpkg.EventRename},
+			{Path: absOldPath, Type: watchpkg.EventRemove},
+			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, zerolog.Nop())
+		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
 
 		// Only the rename should be applied, not the remove
 		rec, ok := local[newPath]

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -176,7 +176,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	}
 
 	session := newRemoteSession(e.conn, currentRemote, version, ctx, e.enc, e.Logger, e.rawKey)
-	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, previousLocal, session); err != nil {
 		return err
 	}
 
@@ -296,7 +296,7 @@ func logPlanActions(logger zerolog.Logger, plan []syncAction) {
 // executePlan executes a list of sync actions.
 // Non-download actions run sequentially on the main connection.
 // Download actions run in parallel using a worker pool of dedicated connections.
-func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLocal map[string]model.FileRecord, previousRemote map[string]model.FileRecord, session *remoteSession) error {
+func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLocal map[string]model.FileRecord, previousRemote, previousLocal map[string]model.FileRecord, session *remoteSession) error {
 	var nonDownloads []syncAction
 	var downloads []syncAction
 	for _, action := range plan {
@@ -322,6 +322,11 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 		switch action.Kind {
 		case syncActionUpload:
 			record := currentLocal[action.Path]
+			// Propagate rename source from previous state so session.push()
+			// can include relatedpath in the WebSocket message.
+			if prev, ok := previousLocal[action.Path]; ok && prev.PreviousPath != "" {
+				record.PreviousPath = prev.PreviousPath
+			}
 			if !filepath.IsLocal(filepath.FromSlash(action.Path)) {
 				return fmt.Errorf("invalid local file path %q", action.Path)
 			}
@@ -336,6 +341,14 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 			if err := session.push(record, data); err != nil {
 				return err
 			}
+			// Clear the rename source only in currentLocal, not previousLocal.
+			// previousLocal is loaded once at the top of RunOnce/doSync and is
+			// not reused within the same sync cycle. Updating currentLocal is
+			// sufficient because the next cycle will reload previousLocal fresh
+			// from storage. This prevents re-sending relatedpath on subsequent
+			// pushes within the same cycle.
+			record.PreviousPath = ""
+			currentLocal[action.Path] = record
 			e.Logger.Info().Str("path", action.Path).Msg("uploaded local file")
 		case syncActionDeleteRemote:
 			if err := session.delete(action.Path); err != nil {

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -341,12 +341,13 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 			if err := session.push(record, data); err != nil {
 				return err
 			}
-			// Clear the rename source only in currentLocal, not previousLocal.
-			// previousLocal is loaded once at the top of RunOnce/doSync and is
-			// not reused within the same sync cycle. Updating currentLocal is
-			// sufficient because the next cycle will reload previousLocal fresh
-			// from storage. This prevents re-sending relatedpath on subsequent
-			// pushes within the same cycle.
+			// Clear PreviousPath as a safety net so the record doesn't
+			// carry rename state into later processing within this cycle.
+			// currentLocal is re-scanned from disk after executePlan returns
+			// (RunOnce and RunContinuous both call scanLocal() post-execution),
+			// which creates fresh FileRecords without PreviousPath. The real
+			// prevention of re-sending relatedpath comes from that re-scan;
+			// this in-memory clear is a belt-and-suspenders measure.
 			record.PreviousPath = ""
 			currentLocal[action.Path] = record
 			e.Logger.Info().Str("path", action.Path).Msg("uploaded local file")

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -498,7 +498,7 @@ func TestExecutePlan(t *testing.T) {
 
 	ctx := context.Background()
 	session := newRemoteSession(conn, remote, 1, ctx, nil, testLogger(), nil)
-	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, previousLocal, session); err != nil {
 		t.Fatal(err)
 	}
 
@@ -587,7 +587,7 @@ func TestExecutePlanParallelDownloads(t *testing.T) {
 
 	ctx := context.Background()
 	session := newRemoteSession(mainConn, currentRemote, 1, ctx, nil, testLogger(), nil)
-	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, previousLocal, session); err != nil {
 		t.Fatal(err)
 	}
 
@@ -658,7 +658,7 @@ func TestExecutePlanParallelSmallSync(t *testing.T) {
 	ctx := context.Background()
 	session := newRemoteSession(mainConn, currentRemote, 1, ctx, nil, testLogger(), nil)
 
-	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, session); err != nil {
+	if err := e.executePlan(ctx, plan, currentLocal, previousRemote, previousLocal, session); err != nil {
 		t.Fatal(err)
 	}
 

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -234,6 +234,7 @@ type mockSyncServer struct {
 	recordsByUID   map[int64]model.FileRecord
 	recordsByPath  map[string]model.FileRecord
 	contentByUID   map[int64][]byte
+	pushMsgs       []map[string]any
 	upgrader       websocket.Upgrader
 	pingCount      int
 	closeAfterPing bool
@@ -359,6 +360,9 @@ func (s *mockSyncServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		case "push":
+			s.mu.Lock()
+			s.pushMsgs = append(s.pushMsgs, msg)
+			s.mu.Unlock()
 			path := stringValue(msg["path"])
 			size := int(int64Value(msg["size"]))
 			pieces := int(int64Value(msg["pieces"]))
@@ -674,6 +678,133 @@ func TestExecutePlanParallelSmallSync(t *testing.T) {
 		if string(data) != expected {
 			t.Fatalf("file %s content mismatch: got %q, want %q", name, string(data), expected)
 		}
+	}
+}
+
+func TestPushRelatedPath(t *testing.T) {
+	t.Parallel()
+	mock := newMockSyncServer(t)
+
+	server := httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[4:]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{"op": "init"}); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var msg map[string]any
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Fatal(err)
+		}
+		if msg["op"] == "ready" {
+			break
+		}
+	}
+
+	ctx := context.Background()
+	session := newRemoteSession(conn, make(map[string]model.FileRecord), 1, ctx, nil, testLogger(), nil)
+
+	// Push with PreviousPath set → relatedpath should be present.
+	record := model.FileRecord{
+		Path:         "new.md",
+		Hash:         "abc",
+		Size:         0,
+		MTime:        1000,
+		PreviousPath: "old.md",
+	}
+	if err := session.push(record, []byte{}); err != nil {
+		t.Fatalf("push with PreviousPath failed: %v", err)
+	}
+
+	mock.mu.Lock()
+	if len(mock.pushMsgs) != 1 {
+		t.Fatalf("expected 1 push message, got %d", len(mock.pushMsgs))
+	}
+	msg := mock.pushMsgs[0]
+	mock.mu.Unlock()
+
+	rp, ok := msg["relatedpath"]
+	if !ok {
+		t.Fatal("expected relatedpath in push message when PreviousPath is set")
+	}
+	if rp != "old.md" {
+		t.Fatalf("expected relatedpath='old.md', got %v", rp)
+	}
+
+	// Push with empty PreviousPath → relatedpath should NOT be present.
+	record2 := model.FileRecord{
+		Path:         "other.md",
+		Hash:         "def",
+		Size:         0,
+		MTime:        2000,
+		PreviousPath: "",
+	}
+	if err := session.push(record2, []byte{}); err != nil {
+		t.Fatalf("push with empty PreviousPath failed: %v", err)
+	}
+
+	mock.mu.Lock()
+	if len(mock.pushMsgs) != 2 {
+		t.Fatalf("expected 2 push messages, got %d", len(mock.pushMsgs))
+	}
+	msg2 := mock.pushMsgs[1]
+	mock.mu.Unlock()
+
+	if _, exists := msg2["relatedpath"]; exists {
+		t.Fatal("expected no relatedpath in push message when PreviousPath is empty")
+	}
+
+	// Push with invalid PreviousPath (starts with /) → relatedpath should NOT be present.
+	record3 := model.FileRecord{
+		Path:         "third.md",
+		Hash:         "ghi",
+		Size:         0,
+		MTime:        3000,
+		PreviousPath: "/absolute/path.md",
+	}
+	if err := session.push(record3, []byte{}); err != nil {
+		t.Fatalf("push with absolute PreviousPath failed: %v", err)
+	}
+
+	mock.mu.Lock()
+	if len(mock.pushMsgs) != 3 {
+		t.Fatalf("expected 3 push messages, got %d", len(mock.pushMsgs))
+	}
+	msg3 := mock.pushMsgs[2]
+	mock.mu.Unlock()
+
+	if _, exists := msg3["relatedpath"]; exists {
+		t.Fatal("expected no relatedpath in push message when PreviousPath starts with /")
+	}
+
+	// Push with invalid PreviousPath (contains ..) → relatedpath should NOT be present.
+	record4 := model.FileRecord{
+		Path:         "fourth.md",
+		Hash:         "jkl",
+		Size:         0,
+		MTime:        4000,
+		PreviousPath: "../escape.md",
+	}
+	if err := session.push(record4, []byte{}); err != nil {
+		t.Fatalf("push with PreviousPath containing .. failed: %v", err)
+	}
+
+	mock.mu.Lock()
+	if len(mock.pushMsgs) != 4 {
+		t.Fatalf("expected 4 push messages, got %d", len(mock.pushMsgs))
+	}
+	msg4 := mock.pushMsgs[3]
+	mock.mu.Unlock()
+
+	if _, exists := msg4["relatedpath"]; exists {
+		t.Fatal("expected no relatedpath in push message when PreviousPath contains ..")
 	}
 }
 

--- a/src/internal/sync/session.go
+++ b/src/internal/sync/session.go
@@ -218,6 +218,11 @@ func (s *remoteSession) push(record model.FileRecord, data []byte) error {
 		"size":      len(encryptedContent),
 		"pieces":    pieces,
 	}
+	// Signal rename source when the file was renamed locally so the server
+	// can treat this as a rename rather than a delete+create.
+	if record.PreviousPath != "" {
+		message["relatedpath"] = s.encryptPath(record.PreviousPath)
+	}
 	if err := s.writeJSON(message); err != nil {
 		return err
 	}

--- a/src/internal/sync/session.go
+++ b/src/internal/sync/session.go
@@ -220,7 +220,7 @@ func (s *remoteSession) push(record model.FileRecord, data []byte) error {
 	}
 	// Signal rename source when the file was renamed locally so the server
 	// can treat this as a rename rather than a delete+create.
-	if record.PreviousPath != "" {
+	if record.PreviousPath != "" && len(record.PreviousPath) > 0 && record.PreviousPath[0] != '/' && !strings.Contains(record.PreviousPath, "..") {
 		message["relatedpath"] = s.encryptPath(record.PreviousPath)
 	}
 	if err := s.writeJSON(message); err != nil {


### PR DESCRIPTION
## Summary
Fix the sync engine to properly send `relatedpath` when pushing a locally-renamed file to the server.

## Problem
When a file is renamed locally, the sync engine detects the rename and stores the old path as `PreviousPath` on the file record, but **never sends it to the server**. The server sees two unrelated operations (delete + create) instead of recognizing the rename. This means:
- Internal wiki links referencing the old filename don't get updated on other clients
- History tracking shows delete+create instead of a rename event

## Changes

### `src/internal/sync/session.go`
- `push()` now includes `relatedpath` in the WebSocket push message when `record.PreviousPath != ""`
- The value is encrypted via `s.encryptPath()` to match the server's expected format

### `src/internal/sync/engine.go`
- `executePlan` now accepts `previousLocal` as an additional parameter
- In the `syncActionUpload` case: enriches the upload record with `PreviousPath` from the previous local state before calling `session.push()`
- After successful push, `PreviousPath` is cleared on `currentLocal` to prevent re-sending on subsequent sync cycles
- Added explanatory comment about why only `currentLocal` is mutated (not `previousLocal`)

### `src/internal/sync/continuous.go`
- Updated `doSync` caller to pass `previousLocal` to `executePlan`

### `src/internal/sync/engine_test.go`
- Updated 3 test call sites to pass `previousLocal`

### Docs
- `docs/sync-protocol.md`: Added "Local Rename Signaling (Client → Server)" section
- `docs/architecture.md`: Added "Local rename propagation to remote" pipeline section

## Verification
- ✅ `go build ./...`
- ✅ `go vet ./...`
- ✅ `go test ./internal/sync/...` — all green

## How It Works
1. Filesystem watcher detects rename via inode tracking → `applyRenameFixups()` sets `PreviousPath`
2. `executePlan` propagates `PreviousPath` from `previousLocal` into the upload record
3. `session.push()` encrypts and includes `relatedpath` in the WebSocket message
4. Server receives: DELETE at oldPath + UPLOAD at newPath with `relatedpath=oldPath` → can now recognize the rename