### PR TITLE
fix(sync): detect local renames in plan and prevent stale remote entries

### DIFF
--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -424,9 +424,14 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			if ev.Type != watchpkg.EventRename {
 				continue
 			}
-			if relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath); err == nil {
-				delete(cs.remote, filepath.ToSlash(relOldPath))
-			}
+		relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath)
+		if err != nil {
+			e.Logger.Warn().Err(err).
+				Str("oldPath", ev.OldPath).
+				Msg("continuous: failed to compute relative path for rename cleanup, skipping")
+			continue
+		}
+		delete(cs.remote, filepath.ToSlash(relOldPath))
 		}
 		currentRemote := make(map[string]model.FileRecord)
 		maps.Copy(currentRemote, previousRemote)

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -30,26 +30,42 @@ const (
 	heartbeatTimeout       = 120 * time.Second
 )
 
+// relPath converts an absolute watcher path to a vault-relative, slash-normalized path.
+func relPath(vaultPath, absPath string) (string, error) {
+	rel, err := filepath.Rel(vaultPath, absPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 // applyRenameFixups mutates previousLocal and previousRemote in-place to reflect
 // file renames detected by the watcher. Without this, a rename from oldPath→newPath
 // would appear as a delete of oldPath + create of newPath in buildPlan.
 // The record's PreviousPath field is set to preserve the rename chain.
-func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord, renames []watchpkg.ScanEvent, vaultPath string, logger zerolog.Logger) {
+// csRemote is also mutated to remove stale old paths so they don't resurface
+// as new remote files when previousRemote and cs.remote are merged.
+func applyRenameFixups(
+	previousLocal, previousRemote map[string]model.FileRecord,
+	csRemote map[string]model.FileRecord,
+	renames []watchpkg.ScanEvent,
+	vaultPath string,
+	logger zerolog.Logger,
+) {
 	for _, ev := range renames {
 		if ev.Type != watchpkg.EventRename {
 			continue
 		}
-		// Convert absolute watcher paths to vault-relative
-		relOldPath, err := filepath.Rel(vaultPath, ev.OldPath)
+		relOldPath, err := relPath(vaultPath, ev.OldPath)
 		if err != nil {
+			logger.Warn().Err(err).Str("oldPath", ev.OldPath).Msg("rename fixup: failed to compute relative old path")
 			continue
 		}
-		relNewPath, err := filepath.Rel(vaultPath, ev.Path)
+		relNewPath, err := relPath(vaultPath, ev.Path)
 		if err != nil {
+			logger.Warn().Err(err).Str("newPath", ev.Path).Msg("rename fixup: failed to compute relative new path")
 			continue
 		}
-		relOldPath = filepath.ToSlash(relOldPath)
-		relNewPath = filepath.ToSlash(relNewPath)
 
 		if oldLocal, ok := previousLocal[relOldPath]; ok {
 			oldLocal.PreviousPath = relOldPath
@@ -71,6 +87,12 @@ func applyRenameFixups(previousLocal, previousRemote map[string]model.FileRecord
 				Str("newPath", relNewPath).
 				Msg("continuous: remote rename applied")
 		}
+
+		// Remove the old path from cs.remote to prevent it from reappearing
+		// as a new remote file in currentRemote (which merges previousRemote + cs.remote).
+		// applyRenameFixups already moved the entry in previousRemote, so the old path
+		// in cs.remote is now stale.
+		delete(csRemote, relOldPath)
 	}
 }
 
@@ -387,7 +409,9 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		pendingRenames = pendingRenames[:0]
 		renamesMu.Unlock()
 
-		applyRenameFixups(previousLocal, previousRemote, snapshot, e.Config.VaultPath, e.Logger)
+		cs.mu.Lock()
+		applyRenameFixups(previousLocal, previousRemote, cs.remote, snapshot, e.Config.VaultPath, e.Logger)
+		cs.mu.Unlock()
 
 		// Flush stale ignorations from the previous sync cycle
 		watcher.FlushIgnored()
@@ -416,23 +440,6 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		cs.mu.Lock()
-		// Remove old rename paths from cs.remote to prevent them from
-		// appearing as new remote files and triggering spurious downloads.
-		// applyRenameFixups already moved the entries in previousRemote,
-		// so without this the old path would reappear in currentRemote.
-		for _, ev := range snapshot {
-			if ev.Type != watchpkg.EventRename {
-				continue
-			}
-		relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath)
-		if err != nil {
-			e.Logger.Warn().Err(err).
-				Str("oldPath", ev.OldPath).
-				Msg("continuous: failed to compute relative path for rename cleanup, skipping")
-			continue
-		}
-		delete(cs.remote, filepath.ToSlash(relOldPath))
-		}
 		currentRemote := make(map[string]model.FileRecord)
 		maps.Copy(currentRemote, previousRemote)
 		for path, record := range cs.remote {

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -419,21 +419,13 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		// Remove old rename paths from cs.remote to prevent them from
 		// appearing as new remote files and triggering spurious downloads.
 		// applyRenameFixups already moved the entries in previousRemote,
-		// so this stale entry would otherwise be treated as a new remote file.
+		// so without this the old path would reappear in currentRemote.
 		for _, ev := range snapshot {
 			if ev.Type != watchpkg.EventRename {
 				continue
 			}
-			relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath)
-			if err != nil {
-				continue
-			}
-			relOldPath = filepath.ToSlash(relOldPath)
-			if _, ok := cs.remote[relOldPath]; ok {
-				e.Logger.Debug().
-					Str("oldPath", relOldPath).
-					Msg("continuous: removing stale remote entry after local rename")
-				delete(cs.remote, relOldPath)
+			if relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath); err == nil {
+				delete(cs.remote, filepath.ToSlash(relOldPath))
 			}
 		}
 		currentRemote := make(map[string]model.FileRecord)

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -416,6 +416,26 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 		}
 
 		cs.mu.Lock()
+		// Remove old rename paths from cs.remote to prevent them from
+		// appearing as new remote files and triggering spurious downloads.
+		// applyRenameFixups already moved the entries in previousRemote,
+		// so this stale entry would otherwise be treated as a new remote file.
+		for _, ev := range snapshot {
+			if ev.Type != watchpkg.EventRename {
+				continue
+			}
+			relOldPath, err := filepath.Rel(e.Config.VaultPath, ev.OldPath)
+			if err != nil {
+				continue
+			}
+			relOldPath = filepath.ToSlash(relOldPath)
+			if _, ok := cs.remote[relOldPath]; ok {
+				e.Logger.Debug().
+					Str("oldPath", relOldPath).
+					Msg("continuous: removing stale remote entry after local rename")
+				delete(cs.remote, relOldPath)
+			}
+		}
 		currentRemote := make(map[string]model.FileRecord)
 		maps.Copy(currentRemote, previousRemote)
 		for path, record := range cs.remote {

--- a/src/internal/sync/continuous.go
+++ b/src/internal/sync/continuous.go
@@ -30,6 +30,29 @@ const (
 	heartbeatTimeout       = 120 * time.Second
 )
 
+// convertRenameSnapshot converts watcher rename events to a vault-relative
+// oldPath → newPath map for use by buildPlan.
+func convertRenameSnapshot(snapshot []watchpkg.ScanEvent, vaultPath string, logger zerolog.Logger) map[string]string {
+	renameMap := make(map[string]string)
+	for _, ev := range snapshot {
+		if ev.Type != watchpkg.EventRename {
+			continue
+		}
+		relOldPath, err := relPath(vaultPath, ev.OldPath)
+		if err != nil {
+			logger.Warn().Err(err).Str("oldPath", ev.OldPath).Msg("convertRenameSnapshot: bad old path")
+			continue
+		}
+		relNewPath, err := relPath(vaultPath, ev.Path)
+		if err != nil {
+			logger.Warn().Err(err).Str("newPath", ev.Path).Msg("convertRenameSnapshot: bad new path")
+			continue
+		}
+		renameMap[relOldPath] = relNewPath
+	}
+	return renameMap
+}
+
 // relPath converts an absolute watcher path to a vault-relative, slash-normalized path.
 func relPath(vaultPath, absPath string) (string, error) {
 	rel, err := filepath.Rel(vaultPath, absPath)
@@ -460,7 +483,11 @@ func (e *Engine) RunContinuous(ctx context.Context) error {
 			})
 		e.logRemoteRenameConflicts(remoteRenameResult, "continuous")
 
-		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
+		// Build a local rename map from the watcher snapshot for buildPlan.
+		// convertRenameSnapshot converts watcher events to a vault-relative oldPath→newPath map.
+		localRenames := convertRenameSnapshot(snapshot, e.Config.VaultPath, e.Logger)
+
+		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir(), localRenames)
 		e.Logger.Info().Int("planned_actions", len(plan)).Msg("continuous: sync plan created")
 		logPlanActions(e.Logger, plan)
 

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -618,3 +618,57 @@ func TestApplyRenameFixups(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyRenameFixupsCsRemote(t *testing.T) {
+	t.Parallel()
+	vaultPath := "/tmp/vault"
+	oldPath := "old/file.md"
+	newPath := "new/file.md"
+	absOldPath := filepath.Join(vaultPath, oldPath)
+	absNewPath := filepath.Join(vaultPath, newPath)
+
+	t.Run("removes stale old path from csRemote", func(t *testing.T) {
+		t.Parallel()
+		local := map[string]model.FileRecord{}
+		remote := map[string]model.FileRecord{
+			oldPath: {Path: oldPath, Hash: "abc", Size: 100, MTime: 1000},
+		}
+		csRemote := map[string]model.FileRecord{
+			oldPath: {Path: oldPath, Hash: "abc", Size: 100, MTime: 1000},
+		}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
+		}
+		applyRenameFixups(local, remote, csRemote, renames, vaultPath, zerolog.Nop())
+
+		if _, ok := csRemote[oldPath]; ok {
+			t.Fatal("expected csRemote old path to be deleted")
+		}
+		rec, ok := remote[newPath]
+		if !ok {
+			t.Fatal("expected new path to exist in remote")
+		}
+		if rec.Hash != "abc" {
+			t.Fatalf("expected hash 'abc', got %s", rec.Hash)
+		}
+		if rec.PreviousPath != oldPath {
+			t.Fatalf("expected PreviousPath %s, got %s", oldPath, rec.PreviousPath)
+		}
+		if _, ok := remote[oldPath]; ok {
+			t.Fatal("expected old path to be deleted from remote")
+		}
+	})
+
+	t.Run("nil csRemote does not panic", func(t *testing.T) {
+		t.Parallel()
+		local := map[string]model.FileRecord{}
+		remote := map[string]model.FileRecord{}
+
+		renames := []watchpkg.ScanEvent{
+			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
+		}
+		// Should not panic when csRemote is nil
+		applyRenameFixups(local, remote, nil, renames, vaultPath, zerolog.Nop())
+	})
+}

--- a/src/internal/sync/continuous_test.go
+++ b/src/internal/sync/continuous_test.go
@@ -533,7 +533,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
+		applyRenameFixups(local, remote, nil, renames, vaultPath, zerolog.Nop())
 
 		// Old path should be gone
 		if _, ok := local[oldPath]; ok {
@@ -565,7 +565,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
+		applyRenameFixups(local, remote, nil, renames, vaultPath, zerolog.Nop())
 
 		rec, ok := remote[newPath]
 		if !ok {
@@ -587,7 +587,7 @@ func TestApplyRenameFixups(t *testing.T) {
 		renames := []watchpkg.ScanEvent{
 			{Path: absNewPath, OldPath: filepath.Join(vaultPath, "nonexistent.md"), Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
+		applyRenameFixups(local, remote, nil, renames, vaultPath, zerolog.Nop())
 
 		// Should not panic, no records added
 		if len(local) != 0 || len(remote) != 0 {
@@ -606,7 +606,7 @@ func TestApplyRenameFixups(t *testing.T) {
 			{Path: absOldPath, Type: watchpkg.EventRemove},
 			{Path: absNewPath, OldPath: absOldPath, Type: watchpkg.EventRename},
 		}
-		applyRenameFixups(local, remote, renames, vaultPath, zerolog.Nop())
+		applyRenameFixups(local, remote, nil, renames, vaultPath, zerolog.Nop())
 
 		// Only the rename should be applied, not the remove
 		rec, ok := local[newPath]

--- a/src/internal/sync/engine.go
+++ b/src/internal/sync/engine.go
@@ -158,7 +158,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	remoteRenameResult := applyRemoteRenameFixups(currentRemote, previousRemote, previousLocal, currentLocal, e.Config.VaultPath, e.Logger, nil)
 	e.logRemoteRenameConflicts(remoteRenameResult, "once")
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir())
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, e.configDir(), nil)
 	e.Logger.Info().
 		Int("planned_actions", len(plan)).
 		Int("local_files", len(currentLocal)).
@@ -322,10 +322,10 @@ func (e *Engine) executePlan(ctx context.Context, plan []syncAction, currentLoca
 		switch action.Kind {
 		case syncActionUpload:
 			record := currentLocal[action.Path]
-			// Propagate rename source from previous state so session.push()
-			// can include relatedpath in the WebSocket message.
-			if prev, ok := previousLocal[action.Path]; ok && prev.PreviousPath != "" {
-				record.PreviousPath = prev.PreviousPath
+			// If this action carries a RelatedPath (rename), propagate it to the push
+			// so session.push() includes the relatedpath field in the WebSocket message.
+			if action.RelatedPath != "" {
+				record.PreviousPath = action.RelatedPath
 			}
 			if !filepath.IsLocal(filepath.FromSlash(action.Path)) {
 				return fmt.Errorf("invalid local file path %q", action.Path)

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -495,7 +495,7 @@ func TestExecutePlan(t *testing.T) {
 	currentRemote := remote
 	previousRemote := map[string]model.FileRecord{}
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", nil)
 	if len(plan) != 2 {
 		t.Fatalf("expected 2 actions, got %d: %+v", len(plan), plan)
 	}
@@ -556,7 +556,7 @@ func TestExecutePlanParallelDownloads(t *testing.T) {
 	currentRemote := mock.cloneRecordsByPath()
 	previousRemote := map[string]model.FileRecord{}
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", nil)
 	if len(plan) != numFiles {
 		t.Fatalf("expected %d actions, got %d", numFiles, len(plan))
 	}
@@ -626,7 +626,7 @@ func TestExecutePlanParallelSmallSync(t *testing.T) {
 	currentRemote := mock.cloneRecordsByPath()
 	previousRemote := map[string]model.FileRecord{}
 
-	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian")
+	plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", nil)
 	if len(plan) != 3 {
 		t.Fatalf("expected 3 actions, got %d", len(plan))
 	}

--- a/src/internal/sync/engine_test.go
+++ b/src/internal/sync/engine_test.go
@@ -808,6 +808,96 @@ func TestPushRelatedPath(t *testing.T) {
 	}
 }
 
+func TestBuildPlanWithLocalRenames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic rename same content", func(t *testing.T) {
+		t.Parallel()
+		previousLocal := map[string]model.FileRecord{
+			"x.md": {Path: "x.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		currentLocal := map[string]model.FileRecord{
+			"y.md": {Path: "y.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		previousRemote := map[string]model.FileRecord{}
+		currentRemote := map[string]model.FileRecord{}
+		localRenames := map[string]string{"x.md": "y.md"}
+
+		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", localRenames)
+		if len(plan) != 1 {
+			t.Fatalf("expected 1 action, got %d: %+v", len(plan), plan)
+		}
+		action := plan[0]
+		if action.Kind != syncActionUpload {
+			t.Fatalf("expected upload, got %s", action.Kind.String())
+		}
+		if action.Path != "y.md" {
+			t.Fatalf("expected path y.md, got %s", action.Path)
+		}
+		if action.RelatedPath != "x.md" {
+			t.Fatalf("expected relatedpath x.md, got %s", action.RelatedPath)
+		}
+	})
+
+	t.Run("rename with changed content", func(t *testing.T) {
+		t.Parallel()
+		previousLocal := map[string]model.FileRecord{
+			"x.md": {Path: "x.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		currentLocal := map[string]model.FileRecord{
+			"y.md": {Path: "y.md", Hash: "def", Size: 12, MTime: 2000},
+		}
+		previousRemote := map[string]model.FileRecord{}
+		currentRemote := map[string]model.FileRecord{}
+		localRenames := map[string]string{"x.md": "y.md"}
+
+		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", localRenames)
+		if len(plan) != 1 {
+			t.Fatalf("expected 1 action, got %d: %+v", len(plan), plan)
+		}
+		action := plan[0]
+		if action.Kind != syncActionUpload {
+			t.Fatalf("expected upload, got %s", action.Kind.String())
+		}
+		if action.Path != "y.md" {
+			t.Fatalf("expected path y.md, got %s", action.Path)
+		}
+		if action.RelatedPath != "x.md" {
+			t.Fatalf("expected relatedpath x.md, got %s", action.RelatedPath)
+		}
+	})
+
+	t.Run("rename target exists in remote with matching hash", func(t *testing.T) {
+		t.Parallel()
+		previousLocal := map[string]model.FileRecord{
+			"x.md": {Path: "x.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		currentLocal := map[string]model.FileRecord{
+			"y.md": {Path: "y.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		previousRemote := map[string]model.FileRecord{}
+		currentRemote := map[string]model.FileRecord{
+			"y.md": {Path: "y.md", Hash: "abc", Size: 10, MTime: 1000},
+		}
+		localRenames := map[string]string{"x.md": "y.md"}
+
+		plan := buildPlan(currentLocal, previousLocal, currentRemote, previousRemote, ".obsidian", localRenames)
+		if len(plan) != 1 {
+			t.Fatalf("expected 1 action, got %d: %+v", len(plan), plan)
+		}
+		action := plan[0]
+		if action.Kind != syncActionUpload {
+			t.Fatalf("expected upload, got %s", action.Kind.String())
+		}
+		if action.Path != "y.md" {
+			t.Fatalf("expected path y.md, got %s", action.Path)
+		}
+		if action.RelatedPath != "x.md" {
+			t.Fatalf("expected relatedpath x.md, got %s", action.RelatedPath)
+		}
+	})
+}
+
 func mustWriteFile(t *testing.T, path string, data []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/src/internal/sync/plan.go
+++ b/src/internal/sync/plan.go
@@ -71,9 +71,14 @@ func buildPlan(
 	}
 
 	for _, path := range paths {
-		// Skip paths that were renamed away — they are not deletes
-		if _, wasRenamedAway := localRenames[path]; wasRenamedAway {
-			continue
+		// Skip paths that were renamed away — they are not deletes,
+		// but only when the rename target still exists locally.
+		// If the target was deleted before this sync cycle, fall through
+		// so the planner can issue a delete-remote for the orphaned path.
+		if newPath, wasRenamedAway := localRenames[path]; wasRenamedAway {
+			if _, exists := currentLocal[newPath]; exists {
+				continue
+			}
 		}
 
 		currentL, hasCurrentL := currentLocal[path]

--- a/src/internal/sync/plan.go
+++ b/src/internal/sync/plan.go
@@ -134,7 +134,7 @@ func recordChanged(hadBefore bool, before model.FileRecord, hasNow bool, now mod
 	if !hadBefore && !hasNow {
 		return false
 	}
-	return before.Hash != now.Hash || before.MTime != now.MTime || before.Size != now.Size || before.Deleted != now.Deleted
+	return before.Hash != now.Hash || before.MTime != now.MTime || before.Size != now.Size || before.Deleted != now.Deleted || before.PreviousPath != now.PreviousPath
 }
 
 func chooseRemote(hasCurrentL bool, currentL model.FileRecord, hasCurrentR bool, currentR model.FileRecord, hasPreviousL bool, previousL model.FileRecord, hasPreviousR bool, previousR model.FileRecord) bool {

--- a/src/internal/sync/plan.go
+++ b/src/internal/sync/plan.go
@@ -38,11 +38,17 @@ func (k syncActionKind) String() string {
 }
 
 type syncAction struct {
-	Path string
-	Kind syncActionKind
+	Path        string
+	Kind        syncActionKind
+	RelatedPath string // old path for rename uploads; empty for other actions
 }
 
-func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[string]model.FileRecord, configDir string) []syncAction {
+func buildPlan(
+	currentLocal, previousLocal,
+	currentRemote, previousRemote map[string]model.FileRecord,
+	configDir string,
+	localRenames map[string]string, // oldPath → newPath from watcher snapshot
+) []syncAction {
 	pathsSet := map[string]struct{}{}
 	for _, collection := range []map[string]model.FileRecord{currentLocal, previousLocal, currentRemote, previousRemote} {
 		for path := range collection {
@@ -57,11 +63,34 @@ func buildPlan(currentLocal, previousLocal, currentRemote, previousRemote map[st
 	}
 	sort.Strings(paths)
 	actions := make([]syncAction, 0, len(paths))
+
+	// Build reverse lookup: newPath → oldPath for O(1) checks
+	renameTargets := make(map[string]string, len(localRenames))
+	for oldPath, newPath := range localRenames {
+		renameTargets[newPath] = oldPath
+	}
+
 	for _, path := range paths {
+		// Skip paths that were renamed away — they are not deletes
+		if _, wasRenamedAway := localRenames[path]; wasRenamedAway {
+			continue
+		}
+
 		currentL, hasCurrentL := currentLocal[path]
 		previousL, hasPreviousL := previousLocal[path]
 		currentR, hasCurrentR := currentRemote[path]
 		previousR, hasPreviousR := previousRemote[path]
+
+		// If this path is a rename target, force an upload with relatedpath
+		// so the server receives the rename as a single operation.
+		if oldPath, isRenameTarget := renameTargets[path]; isRenameTarget && hasCurrentL {
+			actions = append(actions, syncAction{
+				Path:        path,
+				Kind:        syncActionUpload,
+				RelatedPath: oldPath,
+			})
+			continue
+		}
 
 		// Hash match: no changes needed
 		if hasCurrentL && hasCurrentR && !currentL.Folder && currentL.Hash == currentR.Hash {
@@ -134,7 +163,7 @@ func recordChanged(hadBefore bool, before model.FileRecord, hasNow bool, now mod
 	if !hadBefore && !hasNow {
 		return false
 	}
-	return before.Hash != now.Hash || before.MTime != now.MTime || before.Size != now.Size || before.Deleted != now.Deleted || before.PreviousPath != now.PreviousPath
+	return before.Hash != now.Hash || before.MTime != now.MTime || before.Size != now.Size || before.Deleted != now.Deleted
 }
 
 func chooseRemote(hasCurrentL bool, currentL model.FileRecord, hasCurrentR bool, currentR model.FileRecord, hasPreviousL bool, previousL model.FileRecord, hasPreviousR bool, previousR model.FileRecord) bool {

--- a/src/internal/sync/watch/watcher_test.go
+++ b/src/internal/sync/watch/watcher_test.go
@@ -244,7 +244,6 @@ func TestWatcher_IgnorePaths_SuppressesCreate(t *testing.T) {
 	}
 }
 
-
 func TestWatcher_IgnorePaths_FlushIgnored(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Fixes a critical sync bug where local file renames were:
1. **Never uploaded to the server** — `recordChanged()` didn't compare `PreviousPath`, so pure renames (no content change) were invisible to the planner
2. **Triggering spurious downloads** — stale old-path entries in `cs.remote` reappeared in `currentRemote` after `applyRenameFixups` moved them to new paths

## Root Cause

See detailed analysis in branch commits:
- `applyRenameFixups` correctly detected renames and mutated `previousLocal`/`previousRemote`, but the downstream plan builder and remote state merger didn't account for the mutations.

## Changes (6 commits)

| Commit  | Description |
| ------- | ----------- |
| `8788b05` | **fix(sync): detect local renames in plan and prevent stale remote entries** |
| `99cd104` | **refactor(sync): simplify stale remote cleanup after rename** |
| `210e161` | **fix(sync): log warning on failed path rel in rename cleanup** |
| `b91816a` | **refactor: extract relPath helper, merge csRemote cleanup into applyRenameFixups** |
| `7a648b4` | **refactor(sync): make buildPlan rename-aware** — elevated rename handling from hidden `PreviousPath` band-aid to explicit `localRenames` parameter |
| `ade9162` | **test(sync): add unit tests for rename plan logic and csRemote cleanup** |

## Key Design Decisions

1. **Rename handling moved from `recordChanged()` to `buildPlan()`** — `recordChanged` is a low-level hash/mtime comparator; rename is a semantic concept that belongs at the plan level
2. **`cs.remote` cleanup merged into `applyRenameFixups`** — single function for all local rename side effects
3. **`relPath()` helper extracted** — eliminates `filepath.Rel` + `filepath.ToSlash` duplication
4. **Hash-check on rename targets intentionally omitted** — pure renames (unchanged content) have matching hashes; adding a hash guard would prevent `relatedpath` from ever reaching the server

## Verification

| Check | Result |
|-------|--------|
| `go fmt` | PASS |
| `go vet` | PASS |
| `go build` | PASS |
| `go test -race -count=1` | PASS (~41s) |
| `golangci-lint` | PASS (0 issues) |
| Code review | APPROVE |
| Philosophy (8 Laws) | PASS |
| E2E test (real vault) | PASS — rename propagated with `relatedpath`, no spurious downloads |